### PR TITLE
templates: index2: allow default of 2

### DIFF
--- a/templates/index2.html
+++ b/templates/index2.html
@@ -59,7 +59,7 @@
                         <ul>
                             {% for f in get_build_options(c) %}
                             <li>
-                                {% if f.default == 1 %}
+                                {% if f.default != 0 %}
                                 <input onclick='dependencies(this, "{{f.label}}", "{{f.dependency}}");' type="checkbox"
                                        name="{{f.label}}" id="{{f.label}}" value="1" checked>
                                 {% else %}


### PR DESCRIPTION
For fence we recently moved to a new default value of 2, this correctly populates the checkbox in that case.

![image](https://user-images.githubusercontent.com/33176108/182262115-61a43c70-a32d-47bd-9ac1-273c41897aba.png)

I don't think that default of two trickles out to the the actual build, looks like we would still get one. This at least it now correctly defaults the tick box. 