### PR TITLE
scripts: add_build.js: treat all non zero default values to be true

### DIFF
--- a/static/js/add_build.js
+++ b/static/js/add_build.js
@@ -65,6 +65,14 @@ const Features = (() => {
         return 'category_'+category_name.split(" ").join("_");
     }
 
+    function featureIsDisabledByDefault(feature_label) {
+        return getOptionByLabel(feature_label).default == 0;
+    }
+
+    function featureisEnabledByDefault(feature_label) {
+        return !featureIsDisabledByDefault(feature_label);
+    }
+
     function updateDefaults(defines_array) {
         // updates default on the basis of define array passed
         // the define array consists define in format, EXAMPLE_DEFINE or !EXAMPLE_DEFINE
@@ -210,7 +218,7 @@ const Features = (() => {
     function applyDefaults() {
         features.forEach(category => {
             category['options'].forEach(option => {
-                const check = option['default'] == 1;
+                const check = featureisEnabledByDefault(option.label);
                 checkUncheckOptionByLabel(option.label, check);
             });
         });


### PR DESCRIPTION
This allows all non-zero default values to check the corresponding checkbox for the option in the app. Thank you, @IamPete1, for submitting #38. The app has changed since the time you submitted that PR, so it needed to be reworked.
I tested it locally and it worked fine. On main, the geofence option was not being selected whereas on this branch it does.

Screenshot for main:-
![main_test](https://user-images.githubusercontent.com/67995771/235097605-aac0e095-6d98-439e-b358-676cf47b86cc.png)

Screenshot for this branch:-
![Screenshot from 2023-04-28 13-53-04](https://user-images.githubusercontent.com/67995771/235097626-3c5ee3d7-56c0-475c-a888-1e5451eed43d.png)
