### PR TITLE
Improve checkout/clone process to fix missing upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Summary
 
-This is a website that generates a downloadable custom ArduPilot firmware, based on user selection.  
-Website: https://custom.ardupilot.org  
+This is a website that generates a downloadable custom ArduPilot firmware, based on user selection.
+Website: https://custom.ardupilot.org
 Blog post: https://discuss.ardupilot.org/t/gsoc-2021-custom-firmware-builder/74946
 
 ## How to build the server locally for testing
@@ -12,38 +12,70 @@ It is expected that you have an environment where ArduPilot can be built. Otherw
 
 1. Fork and Clone the ArduPilot/CustomBuild repository
 
-2. In the directory containg the CustomBuild repo just cloned, create a /base subdirectory and change to that directory.
+2. In the directory containing the CustomBuild repo just cloned, create a /base subdirectory and change to that directory.
 
-3. Clone a fork of the ArduPilot/ardupilot repository. The structure should appear similar to that below:
+3. Clone a fork of the ArduPilot/ardupilot repository.
 
+### Detailed Instructions for Ubuntu
+
+For example, here are the commands for Ubuntu.
+
+If not already set up, [configure your Git username](https://git-scm.com/docs/git-config#Documentation/git-config.txt-credentialusername):
+Substitute `your-github-account` with your Github username.
+```
+git config --global credential.username your-github-account
+```
+
+Next, clone the repositories:
+```bash
+git config credential.username your-github-account
+cd ~
+git clone git@github.com:$(git config credential.username)/CustomBuild.git
+git clone --depth 1 git@github.com:$(git config credential.username)/ardupilot.git base/ardupilot
+```
+
+Finally, add the upstream ArduPilot to your remotes.
+```bash
+git -C base/ardupilot remote add upstream git@github.com:ardupilot/ardupilot.git
+git -C base/ardupilot fetch --depth 1 upstream
+```
 
 ### Directory structure
-default directory structure is as follows
+
+The default directory structure is as follows:
 ```
 /home/<username>
 -CustomBuild
 -base
 --ardupilot
 ```
-### Install Flask
+
+
+### Install Dependencies
+
+```bash
+cd ~/CustomBuild
+python3 -m pip install --user --upgrade --requirement requirements.txt
 ```
-python3 -m pip install --user -U flask
-```
-Use `--basedir` to adjust the base directory, the default one is `base`.
 
 ### Running
+
 To run, in the CustomBuild directory execute the following command:
 
-```
+```bash
+cd ~/CustomBuild
 ./app.py
 ```
+
+Use `--basedir` to adjust the base directory. The default one is `base`.
+
 Once running, you will be given a link to a local host port in which the interface is displayed for the build server. It can be run at this point. Output will NOT be accessible via the interface buttons for build directory. Builds are stored in the base/builds subdirectory
 
 ### For Apache web server on Ubuntu with WSGI
 To create a full server with network access:
 
 * Install mod_wsgi for python 3:
-```
+```bash
 sudo apt-get install apache2 libapache2-mod-wsgi-py3 python3 python3-pip
 ```
 
@@ -56,19 +88,19 @@ sudo apt-get install apache2 libapache2-mod-wsgi-py3 python3 python3-pip
 * Edit the file as necessary for your use case
 
 * Enable the file:
-```
+```bash
 sudo a2ensite CustomBuild.conf
 ```
 * To restart Apache:
-```
+```bash
 sudo apache2ctl graceful
 ```
 * To stop Apache:
-```
+```bash
 sudo apache2ctl stop
 ```
 * To start Apache:
-```
+```bash
 sudo apache2ctl start
 ```
 Webpage: 127.0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
# Purpose

This fixes numerous omitted steps that resulted in failed default behavior and replaces #61.

## Issues fixed

* No remote upstream added
* No requests library installed
* Converted from manual python deps install to a `requirements.txt` file (standard python practice)
* Added terminal commands to make it easier for ubuntu devs to get started with the custom build server
* spelling 
* no syntax highlighting for bash commands

## Logs

Here is one failure, because the user never added `upstream` as a remote or fetched it:
```
$ ./app.py 
[2023-11-25 11:54:07,195] INFO in app: Creating /home/ryan/Dev/ros2_ws/src/base/builds
[2023-11-25 11:54:07,195] INFO in app: Got queue lock
[2023-11-25 11:54:07,221] INFO in app: Initial fetch
[2023-11-25 11:54:07,221] INFO in app: Running git rev-parse upstream/master in /home/ryan/Dev/ros2_ws/src/base/ardupilot
fatal: ambiguous argument 'upstream/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Traceback (most recent call last):
  File "/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py", line 544, in <module>
    checkout_branch(get_default_branch_name(), s_dir=sourcedir, fetch_and_reset=True)
  File "/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py", line 144, in checkout_branch
    if not on_branch(targetBranch):
  File "/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py", line 127, in on_branch
    git_hash_target = get_git_hash(branch)
  File "/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py", line 124, in get_git_hash
    return subprocess.check_output(['git', 'rev-parse', branch], cwd=sourcedir, encoding='utf-8', shell=False).rstrip()
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', 'upstream/master']' returned non-zero exit status 128.
```

Another failure, the dev was never told to install requests.
```
$ ./app.py 
/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py:13: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.dir_util import copy_tree
Traceback (most recent call last):
  File "/home/ryan/Dev/ros2_ws/src/CustomBuild/./app.py", line 18, in <module>
    import requests
ModuleNotFoundError: No module named 'requests
```

After this change, the following behavior is now correct:
```
$ ./app.py 
[2023-11-25 12:01:57,252] INFO in app: Got queue lock
[2023-11-25 12:01:57,252] INFO in app: Initial fetch
[2023-11-25 12:01:57,252] INFO in app: Running 'git rev-parse upstream/master' in /home/ryan/Dev/ros2_ws/src/base/ardupilot
[2023-11-25 12:01:57,254] INFO in app: Expected branch git-hash 'ea237724c772a0dd5ec3c30dba3f3eca5c49f46a'
[2023-11-25 12:01:57,254] INFO in app: Running 'git rev-parse HEAD' in /home/ryan/Dev/ros2_ws/src/base/ardupilot
[2023-11-25 12:01:57,256] INFO in app: Current branch git-hash 'ea237724c772a0dd5ec3c30dba3f3eca5c49f46a'
[2023-11-25 12:01:57,256] INFO in app: Running git: git fetch upstream
[2023-11-25 12:01:58,617] INFO in app: Running git: git reset --hard upstream/master
HEAD is now at ea237724 Tools: autotest: Fix junit printing for double str
[2023-11-25 12:01:58,639] INFO in app: Running 'git rev-parse HEAD' in /home/ryan/Dev/ros2_ws/src/base/ardupilot
[2023-11-25 12:01:58,641] INFO in app: Updating submodules
[2023-11-25 12:01:58,641] INFO in app: Running git: git submodule update --recursive --force --init
Submodule 'modules/ChibiOS' (https://github.com/ArduPilot/ChibiOS.git) registered for path 'modules/ChibiOS'
Submodule 'modules/CrashDebug' (https://github.com/ardupilot/CrashDebug) registered for path 'modules/CrashDebug'
Submodule 'modules/DroneCAN/DSDL' (https://github.com/DroneCAN/DSDL.git) registered for path 'modules/DroneCAN/DSDL'
Submodule 'modules/DroneCAN/dronecan_dsdlc' (https://github.com/DroneCAN/dronecan_dsdlc) registered for path 'modules/DroneCAN/dronecan_dsdlc'
Submodule 'modules/DroneCAN/libcanard' (https://github.com/DroneCAN/libcanard) registered for path 'modules/DroneCAN/libcanard'
Submodule 'modules/DroneCAN/pydronecan' (https://github.com/DroneCAN/pydronecan) registered for path 'modules/DroneCAN/pydronecan'
Submodule 'modules/Micro-CDR' (https://github.com/ardupilot/Micro-CDR.git) registered for path 'modules/Micro-CDR'
Submodule 'modules/Micro-XRCE-DDS-Client' (https://github.com/ardupilot/Micro-XRCE-DDS-Client.git) registered for path 'modules/Micro-XRCE-DDS-Client'
Submodule 'modules/gbenchmark' (https://github.com/google/benchmark.git) registered for path 'modules/gbenchmark'
Submodule 'modules/gsoap' (https://github.com/ArduPilot/gsoap) registered for path 'modules/gsoap'
Submodule 'gtest' (https://github.com/ArduPilot/googletest) registered for path 'modules/gtest'
Submodule 'modules/mavlink' (https://github.com/ArduPilot/mavlink) registered for path 'modules/mavlink'
Submodule 'modules/waf' (https://github.com/ArduPilot/waf.git) registered for path 'modules/waf'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/ChibiOS'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/CrashDebug'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/DroneCAN/DSDL'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/DroneCAN/dronecan_dsdlc'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/DroneCAN/libcanard'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/DroneCAN/pydronecan'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/Micro-CDR'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/Micro-XRCE-DDS-Client'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/gbenchmark'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/gsoap'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/gtest'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/mavlink'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/waf'...
Submodule path 'modules/ChibiOS': checked out '3ef1657d53e643aa61f7268ab4b8596bf6826fdb'
Submodule 'ext/lwip' (https://github.com/ArduPilot/lwip.git) registered for path 'modules/ChibiOS/ext/lwip'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/ChibiOS/ext/lwip'...
Submodule path 'modules/ChibiOS/ext/lwip': checked out '6ca936f6b588cee702c638eee75c2436e6cf75de'
Submodule path 'modules/CrashDebug': checked out '599965086437137ec0fe66e185611f43f335f889'
Submodule 'CrashCatcher' (https://github.com/ardupilot/CrashCatcher.git) registered for path 'modules/CrashDebug/CrashCatcher'
Submodule 'mri' (https://github.com/ardupilot/mri.git) registered for path 'modules/CrashDebug/mri'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/CrashDebug/CrashCatcher'...
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/CrashDebug/mri'...
Submodule path 'modules/CrashDebug/CrashCatcher': checked out '4cf6e11df3a081b0f573a7834ed8e1e4000af73e'
Submodule 'CppUTest' (https://github.com/ardupilot/CppUTest.git) registered for path 'modules/CrashDebug/CrashCatcher/CppUTest'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/CrashDebug/CrashCatcher/CppUTest'...
Submodule path 'modules/CrashDebug/CrashCatcher/CppUTest': checked out '011f371fdb5d7e441fb023be67295783e053df4a'
Submodule path 'modules/CrashDebug/mri': checked out 'b35c89451b41a45b7f5b580acaff555315ac88e2'
Submodule 'CppUTest' (https://github.com/ardupilot/CppUTest.git) registered for path 'modules/CrashDebug/mri/CppUTest'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/CrashDebug/mri/CppUTest'...
Submodule path 'modules/CrashDebug/mri/CppUTest': checked out '011f371fdb5d7e441fb023be67295783e053df4a'
Submodule path 'modules/DroneCAN/DSDL': checked out 'de93d9c8bb76de1b093050e3a31e4d4ce539c577'
Submodule path 'modules/DroneCAN/dronecan_dsdlc': checked out 'ebaf96860a11a4cc43c01df6b651df143c6cde2d'
Submodule path 'modules/DroneCAN/libcanard': checked out '22102c717db29cc2a2c2869ff80f3e4389704d89'
Submodule 'drivers/avr/avr-can-lib' (https://github.com/rennerm/avr-can-lib) registered for path 'modules/DroneCAN/libcanard/drivers/avr/avr-can-lib'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/DroneCAN/libcanard/drivers/avr/avr-can-lib'...
Submodule path 'modules/DroneCAN/libcanard/drivers/avr/avr-can-lib': checked out '9c6bc9118de66d6edaf1b8539e2b9717ba26d123'
Submodule path 'modules/DroneCAN/pydronecan': checked out '19fdf2e5b383243ccdb1094edae0603cf11469e8'
Submodule path 'modules/Micro-CDR': checked out '3d1b17703c7cf4f22def2910bc845bdb5152d7b5'
Submodule path 'modules/Micro-XRCE-DDS-Client': checked out '97175304425c5bee87c6fddd99de1ef8d0c394dc'
Submodule path 'modules/gbenchmark': checked out 'd572f4777349d43653b21d6c2fc63020ab326db2'
Submodule path 'modules/gsoap': checked out 'e1f690585d4803402584962bfaa8240ecaf1db30'
Submodule path 'modules/gtest': checked out 'c5fed93f941865a0e912e9baf46ded713506590a'
Submodule path 'modules/mavlink': checked out 'dccd8555cd601467dc793ea9abf85caa63c0a9e8'
Submodule 'pymavlink' (https://github.com/ArduPilot/pymavlink.git) registered for path 'modules/mavlink/pymavlink'
Cloning into '/home/ryan/Dev/ros2_ws/src/base/ardupilot/modules/mavlink/pymavlink'...
Submodule path 'modules/mavlink/pymavlink': checked out '19e385ccb4b6cbe2d08a8689dfcc586389fe14ce'
Submodule path 'modules/waf': checked out '1b1625b8e7da6e1307d73335cb995fa8813d5950'
[2023-11-25 12:02:54,747] INFO in app: Python version is: 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0]
 * Serving Flask app 'app'
 * Debug mode: off
[2023-11-25 12:02:54,749] INFO in _internal: WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:5000
[2023-11-25 12:02:54,749] INFO in _internal: Press CTRL+C to quit
```