### PR TITLE
Move dictionary to list releases outside app.py and use a json file instead

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from threading import Thread, Lock
 import sys
 import re
 import requests
+import jsonschema
 # run at lower priority
 os.nice(20)
 
@@ -74,8 +75,11 @@ def ref_is_tag(commit_reference):
 
 def load_remotes():
     # load file contianing vehicles listed to be built for each remote along with the braches/tags/commits on which the firmware can be built
-    with open(os.path.join(basedir, 'configs', 'remotes.json'), 'r')  as f:
+    with open(os.path.join(basedir, 'configs', 'remotes.json'), 'r')  as f, open(os.path.join(appdir, 'remotes.schema.json'), 'r') as s:
         remotes = json.loads(f.read())
+        schema = json.loads(s.read())
+        # validate schema
+        jsonschema.validate(remotes, schema=schema)
         set_remotes(remotes)
 
 

--- a/remotes.json.sample
+++ b/remotes.json.sample
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "ap-static",
+    "url": "https://github.com/ardupilot/ardupilot.git",
+    "vehicles": [
+      {
+        "name": "Copter",
+        "releases": [
+          {
+            "release_type": "latest",
+            "version_number": "4.6.0",
+            "ap_build_atrifacts_url": "https://firmware.ardupilot.org/Copter/latest",
+            "commit_reference": "refs/heads/master"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "cool-user-007",
+    "url": "https://github.com/cool-user-007/ardupilot.git",
+    "vehicles": [
+      {
+        "name": "Copter",
+        "releases": [
+          {
+            "release_type": "Custom",
+            "version_number": "Custom",
+            "commit_reference": "refs/tags/Copter-4.5.2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ardupilot",
+    "url": "https://github.com/ardupilot/ardupilot.git",
+    "vehicles": [
+      {
+        "name": "Copter",
+        "releases": [
+          {
+            "release_type": "latest",
+            "version_number": "4.6.0",
+            "ap_build_atrifacts_url": "https://firmware.ardupilot.org/Copter/latest",
+            "commit_reference": "202cc6ae9d326a172be5ec1120d79595a6ddae36"
+          },
+          {
+            "release_type": "stable",
+            "version_number": "4.3.0",
+            "ap_build_atrifacts_url": "https://firmware.ardupilot.org/Copter/stable-4.3.0",
+            "commit_reference": "93448b71380c417644c9082b7b23e80fb982b626"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/remotes.schema.json
+++ b/remotes.schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Remotes",
+    "type": "array",
+    "description": "remote-wise list of vehicles and their available versions to build on Custom Build Server",
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Remote name"
+        },
+        "url": {
+          "type": "string",
+          "description": "Remote url"
+        },
+        "vehicles": {
+          "type": "array",
+          "description": "list of vehicles listed for building for that remote",
+          "items": {
+            "type": "object",
+            "description": "Vehicle object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of vehicle"
+              },
+              "releases": {
+                "type": "array",
+                "description": "list of releases for that vehicle",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "release_type": {
+                      "type": "string",
+                      "description": "release type, i.e., stable, beta, master"
+                    },
+                    "version_number": {
+                      "type": "string",
+                      "description": "Ardupilot version number for that release"
+                    },
+                    "ap_build_atrifacts_url": {
+                      "type": "string",
+                      "description": "url to build artifacts at AP firmware server to fetch features.txt"
+                    },
+                    "commit_reference": {
+                      "type": "string",
+                      "description": "reference to commit for that release, this can be branch name, tag or git hash"
+                    }
+                  },
+                  "required": [
+                    "commit_reference"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "releases"
+            ]
+          }
+        }
+      },
+      "required": [
+        "name",
+        "url",
+        "vehicles"
+      ]
+    }
+  }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 requests
+jsonschema

--- a/static/js/add_build.js
+++ b/static/js/add_build.js
@@ -374,7 +374,11 @@ function onVersionChange(new_version) {
     let elements_to_block = ['vehicle', 'version', 'board', 'submit', 'reset_def', 'exp_col_button'];
     enableDisableElementsById(elements_to_block, false);
     let vehicle = document.getElementById("vehicle").value;
-    let request_url = `/boards_and_features/${vehicle}/${new_version}`;
+    let arr = new_version.split("/");
+    let remote = arr.shift();
+    let commit_ref = arr.join("/");
+    commit_ref = btoa(commit_ref).replace(/\//g, "_").replace(/\+/g, "-"); // url-safe base64 encoding
+    let request_url = `/boards_and_features/${vehicle}/${remote}/${commit_ref}`;
 
     // create a temporary container to set spinner inside it
     let temp_container = document.createElement('div');
@@ -429,7 +433,12 @@ function fetchAndUpdateDefaults() {
     let version = document.getElementById('version').value;
     let vehicle = document.getElementById('vehicle').value;
     let board = document.getElementById('board').value;
-    let request_url = '/get_defaults/'+vehicle+'/'+version+'/'+board;
+
+    let arr = version.split("/");
+    let remote = arr.shift();
+    let commit_ref = arr.join("/");
+    commit_ref = btoa(commit_ref).replace(/\//g, "_").replace(/\+/g, "-"); // url-safe base64 encoding
+    let request_url = '/get_defaults/'+vehicle+'/'+remote+'/'+commit_ref+'/'+board;
     sendAjaxRequestForJsonResponse(request_url)
         .then((json_response) => {
             Features.updateDefaults(json_response);

--- a/templates/add_build.html
+++ b/templates/add_build.html
@@ -53,19 +53,17 @@
               <form id="build-form" action="/generate" method="post">
                 <div class="row">
                     <div class="col-md-4 col-sm-6 mb-2 d-flex align-items-end">
-                        <div class="container-fluid">
-                            <label for="vehicle" class="form-label"><strong>Select vehicle</strong></label>
-                            <select name="vehicle" id="vehicle" class="form-select" aria-label="Select vehicle" onchange="onVehicleChange(this.value);">
-                                {% for vehicle in get_vehicle_names() %}
-                                <option value="{{vehicle}}" {% if vehicle == get_default_vehicle_name() %} selected {% endif %}>{{vehicle}}</option>
-                                {% endfor %}
-                            </select>
+                        <div class="container-fluid" id="vehicle_list">
+                            <div class="container-fluid d-flex align-content-between">
+                                <strong>Fetching Vehicles...</strong>
+                                <div class="spinner-border ms-auto" role="status" aria-hidden="true"></div>
+                            </div>
                         </div>
                     </div>
                     <div class="col-md-4 col-sm-6 mb-2 d-flex align-items-end">
-                        <div class="container-fluid" id="branch_list">
+                        <div class="container-fluid" id="version_list">
                             <div class="container-fluid d-flex align-content-between">
-                                <strong>Fetching branches...</strong>
+                                <strong>Fetching versions...</strong>
                                 <div class="spinner-border ms-auto" role="status" aria-hidden="true"></div>
                             </div>
                         </div>


### PR DESCRIPTION

This moves the dictionary we were using to list branches for builds outside of app.py. Major reasons for doing this are:

Configurations like these should not remain with the main application itself.
There is no point in versioning this information with git. This configuration keeps changing very regularly. Whenever we do releases, want to delist a branch, or make any other changes, this config changes.
We can update this file at regular intervals and reload the server to automatically sync with releases at firmware.ardupilot.org.
For this, I have made changes to the app to remove the dictionary from app.py and load it from remotes.json instead. We also validate this file against remotes.schema.json to ensure the structure of the file is correct and valid. I am working on a Python script as well to autoupdate this file on the server. I will be making a separate PR for this.

This also opens doors for allowing builds for different remotes in the future. The remotes.json file is structured in such a way that we could add entries for various releases/branches/commits/tags for a remote, as well as different remotes themselves. The logic to handle different remotes can be added in the future. This is basically the first step in that direction.

I have attempted to remove all references to branches in the application and renamed them to versions/releases, as there can be multiple releases on the same branch (e.g., copter stable-4.5.1 and stable-4.5.2), and a user should be able to choose whichever stable version they want to build.

After merging, this should go to the beta server first for thorough testing. We can then put this on the main server together with the next changes coming up.