### PR TITLE
Remove leftover console.log statements used for debugging

### DIFF
--- a/static/js/add_build.js
+++ b/static/js/add_build.js
@@ -190,7 +190,6 @@ const Features = (() => {
 
     function updateGlobalCheckboxState() {
         const total_options = Object.keys(defines_dictionary).length;
-        console.log(selected_options + "/" + total_options);
         let global_checkbox = document.getElementById("check-uncheck-all");
 
         let indeterminate_state = false;


### PR DESCRIPTION
This were probably used for debugging stuff and were mistakenly merged. Can be safely removed. Thanks!