### PR TITLE
scripts: initiliase empty versions map

### DIFF
--- a/scripts/fetch_whitelisted_tags.py
+++ b/scripts/fetch_whitelisted_tags.py
@@ -29,7 +29,6 @@ import json
 import optparse
 import os
 import requests
-import collections
 
 
 # TODO: move this to base/configs/whitelisted_custom_tag_remotes.json
@@ -97,11 +96,11 @@ def construct_versions_map(remotes, vehicles):
     }
     """
 
-    ret = collections.defaultdict(
-        lambda: collections.defaultdict(
-            list
-        )
-    )
+    ret = {
+        remote: {
+            vehicle: [] for vehicle in vehicles
+        } for remote in remotes
+    }
 
     for remote in remotes:
         try:


### PR DESCRIPTION
We need to initialise this map with empty lists to make sure we still process the remotes and vehicles for which we do not find any new tags. If we don't do this, the method which updates remotes.json file simply skips those remotes and vehicles, which in turn leads to the tags that have been deleted stay there. So if we don't have any tags for a remote and vehicle, we specify it explicitly.