### PR TITLE
scripts: cleanup fetch_whitelisted_tags_*.log files using crobjob script

### DIFF
--- a/scripts/update_remotes_json_cronjob.sh
+++ b/scripts/update_remotes_json_cronjob.sh
@@ -24,7 +24,9 @@ TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 # Function to clean up old log files
 cleanup_old_logs() {
   # Find and sort log files by modification time, oldest first
-  LOG_FILES=($(ls -1t ${LOGDIR}/fetch_releases_*.log 2>/dev/null))
+  LOG_FILES=($(ls -1t ${LOGDIR}/fetch_releases_*.log \
+                      ${LOGDIR}/fetch_whitelisted_tags_*.log \
+                      2>/dev/null))
 
   # Count the number of log files
   NUM_LOG_FILES=${#LOG_FILES[@]}


### PR DESCRIPTION
`fetch_whitelisted_tags.py` generate these log files. We need to include these files in the list of files to be cleaned up.