### PR TITLE
Chage default path for base directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # redis dump
 dump.rdb
+
+# base directory
+base/

--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ import optparse
 parser = optparse.OptionParser("app.py")
 
 parser.add_option("", "--basedir", type="string",
-                  default=os.path.abspath(os.path.join(os.path.dirname(__file__),"..","base")),
+                  default=os.path.abspath(os.path.join(os.path.dirname(__file__),".","base")),
                   help="base directory")
 
 cmd_opts, cmd_args = parser.parse_args()

--- a/scripts/fetch_releases.py
+++ b/scripts/fetch_releases.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
     parser.add_option(
         "", "--basedir", type="string",
         default=os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "base")
+            os.path.join(os.path.dirname(__file__), "..", "base")
         ),
         help="base directory"
     )

--- a/scripts/fetch_whitelisted_tags.py
+++ b/scripts/fetch_whitelisted_tags.py
@@ -280,7 +280,7 @@ if __name__ == "__main__":
     parser.add_option(
         "", "--basedir", type="string",
         default=os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "base")
+            os.path.join(os.path.dirname(__file__), "..", "base")
         ),
         help="base directory"
     )


### PR DESCRIPTION
It is more intuitive to keep it inside the repo directory (and let git ignore it) unless explicitly specified.