### PR TITLE
web: allow setting BASEDIR through env

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -47,7 +47,10 @@ import optparse
 parser = optparse.OptionParser("app.py")
 
 parser.add_option("", "--basedir", type="string",
-                  default=os.path.abspath(os.path.join(os.path.dirname(__file__),"..","base")),
+                  default=os.getenv(
+                      key="CBS_BASEDIR",
+                      default=os.path.abspath(os.path.join(os.path.dirname(__file__),"..","base"))
+                  ),
                   help="base directory")
 
 cmd_opts, cmd_args = parser.parse_args()


### PR DESCRIPTION
If basedir option is not used, the default behaviour should be to try getting the path from the environment.

If still not found, default path should be used.