### PR TITLE
Move remotes.json reload call to metadata_manager

### DIFF
--- a/metadata_manager/core.py
+++ b/metadata_manager/core.py
@@ -207,6 +207,7 @@ class VersionsFetcher:
         )
         self.__task__runner = TaskRunner(tasks=tasks)
         self.repo = ap_repo
+        self.reload_remotes_json()
         VersionsFetcher.__singleton = self
 
     def start(self) -> None:

--- a/web/app.py
+++ b/web/app.py
@@ -393,8 +393,6 @@ try:
 except IOError:
     app.logger.info("No queue lock")
 
-versions_fetcher.reload_remotes_json()
-
 app.logger.info('Python version is: %s' % sys.version)
 
 def get_auth_token():


### PR DESCRIPTION
Part of cleaning up app.py and moving things to dedicated modules.