### PR TITLE
Add and use GitRepo.clone_if_needed method

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -69,14 +69,11 @@ REMOTES = None
 # LOCKS
 queue_lock = Lock()
 
-try:
-    repo = ap_git.GitRepo(sourcedir)
-except FileNotFoundError:
-    repo = ap_git.GitRepo.clone(
-        source="https://github.com/ardupilot/ardupilot.git",
-        dest=sourcedir,
-        recurse_submodules=True,
-    )
+repo = ap_git.GitRepo.clone_if_needed(
+    source="https://github.com/ardupilot/ardupilot.git",
+    dest=sourcedir,
+    recurse_submodules=True,
+)
 
 ap_src_metadata_fetcher = metadata_manager.APSourceMetadataFetcher(
     ap_repo=repo


### PR DESCRIPTION
This method would help in ensuring a git repository exists at a path before initialising a GitRepo object. Depending on the options passed, it will do a fresh clone if a git repo does not exist at a given path or is broken.