### PR TITLE
Set default board in app.py instead of metadata_manager

### DIFF
--- a/metadata_manager/core.py
+++ b/metadata_manager/core.py
@@ -43,7 +43,7 @@ class APSourceMetadataFetcher:
         APSourceMetadataFetcher.__singleton = self
 
     def get_boards_at_commit(self, remote: str,
-                             commit_ref: str) -> tuple:
+                             commit_ref: str) -> list:
         """
         Retrieves a list of boards available for building at a
         specified commit and returns the list and the default board.
@@ -53,11 +53,7 @@ class APSourceMetadataFetcher:
             commit_ref (str): The commit reference to check out.
 
         Returns:
-            tuple: A tuple containing:
-                - boards (list): A list of boards available at the
-                                 specified commit.
-                - default_board (str): The first board in the sorted list,
-                                       designated as the default.
+            list: A list of boards available at the specified commit.
         """
         tstart = time.time()
         import importlib.util
@@ -93,8 +89,7 @@ class APSourceMetadataFetcher:
             f"Took {(time.time() - tstart)} seconds to get boards"
         )
         boards.sort()
-        default_board = boards[0]
-        return (boards, default_board)
+        return boards
 
     def get_build_options_at_commit(self, remote: str,
                                     commit_ref: str) -> list:
@@ -365,7 +360,7 @@ class VersionsFetcher:
 
         # update git repo with latest remotes list
         self.__sync_remotes_with_ap_repo()
-    
+
     def __ensure_remotes_json(self) -> None:
         """
         Ensures remotes.json exists and is a valid JSON file.

--- a/web/app.py
+++ b/web/app.py
@@ -439,7 +439,7 @@ def generate():
             raise Exception("Commit reference invalid or not listed to be built for given vehicle for remote")
 
         chosen_board = request.form['board']
-        boards_at_commit, _ = ap_src_metadata_fetcher.get_boards_at_commit(
+        boards_at_commit = ap_src_metadata_fetcher.get_boards_at_commit(
             remote=chosen_remote,
             commit_ref=chosen_commit_reference
         )
@@ -596,7 +596,7 @@ def boards_and_features(vehicle_name, remote_name, commit_reference):
     app.logger.info('Board list and build options requested for %s %s %s' % (vehicle_name, remote_name, commit_reference))
     # getting board list for the branch
     with repo.get_checkout_lock():
-        (boards, default_board) = ap_src_metadata_fetcher.get_boards_at_commit(
+        boards = ap_src_metadata_fetcher.get_boards_at_commit(
             remote=remote_name,
             commit_ref=commit_reference
         )
@@ -627,7 +627,7 @@ def boards_and_features(vehicle_name, remote_name, commit_reference):
     # creating result dictionary
     result = {
         'boards' : boards,
-        'default_board' : default_board,
+        'default_board' : boards[0],
         'features' : features,
     }
     # return jsonified result dict


### PR DESCRIPTION
The default board is not sourced from board_list.py, so setting it in metadata_manager makes no sense. The responsibility of metadata_manager is to simply pass the list of boards retrieved from board_list.py at a commit. The caller should determine which board to set as the default.