### PR TITLE
Add and use build_manager and builder modules

### DIFF
--- a/build_manager/__init__.py
+++ b/build_manager/__init__.py
@@ -1,0 +1,17 @@
+from .cleaner import BuildArtifactsCleaner
+from .progress_updater import BuildProgressUpdater
+from .manager import (
+    BuildManager,
+    BuildInfo,
+    BuildProgress,
+    BuildState,
+)
+
+__all__ = [
+    "BuildArtifactsCleaner",
+    "BuildProgressUpdater",
+    "BuildManager",
+    "BuildInfo",
+    "BuildProgress",
+    "BuildState",
+]

--- a/build_manager/cleaner.py
+++ b/build_manager/cleaner.py
@@ -1,0 +1,109 @@
+from utils import TaskRunner
+from .manager import BuildManager as bm
+import logging
+import shutil
+import pathlib
+
+
+class BuildArtifactsCleaner:
+    """
+    Class responsible for cleaning up stale build
+    artifacts from the build output directory.
+    """
+
+    __singleton = None
+
+    def __init__(self) -> None:
+        """
+        Initialises the BuildArtifactsCleaner instance.
+        This class depends on the BuildManager singleton,
+        so it ensures that the BuildManager is initialized
+        before proceeding.
+
+        Raises:
+            RuntimeError: If BuildManager is not initialized or
+            if another instance of BuildArtifactsCleaner already
+            exists (enforcing the singleton pattern).
+        """
+
+        if bm.get_singleton() is None:
+            raise RuntimeError("BuildManager should be initialised first")
+
+        if BuildArtifactsCleaner.__singleton:
+            raise RuntimeError("BuildArtifactsCleaner must be a singleton")
+
+        # Calls the __run method every 60 seconds.
+        tasks = (
+            (self.__run, 60),
+        )
+        # This spins up a new thread
+        self.__runner = TaskRunner(tasks=tasks)
+        self.logger = logging.getLogger(__name__)
+        BuildArtifactsCleaner.__singleton = self
+
+    def start(self) -> None:
+        """
+        Start BuildArtifactsCleaner.
+        """
+        self.logger.info("Starting BuildArtifactsCleaner")
+        self.__runner.start()
+
+    def __stale_artifacts_path_list(self) -> list:
+        """
+        Returns a list of paths to stale build artifacts.
+
+        Returns:
+            list: A list of file paths for stale artifacts.
+        """
+        dir_to_scan = pathlib.Path(bm.get_singleton().get_outdir())
+        self.logger.debug(
+            f"Scanning directory: {dir_to_scan} for stale artifacts"
+        )
+        all_build_ids = bm.get_singleton().get_all_build_ids()
+        self.logger.debug(f"Retrieved all build IDs: {all_build_ids}")
+
+        dirs_to_keep = [
+            pathlib.Path(
+                bm.get_singleton().get_build_artifacts_dir_path(build_id)
+            )
+            for build_id in all_build_ids
+        ]
+
+        stale_artifacts = []
+        for f in dir_to_scan.iterdir():
+            # Exclude status.json
+            # To-do: move status.json out of this directory
+            if f.name == "status.json":
+                continue
+
+            # Check if the current file/dir falls under any directories to keep
+            keep_file = any(
+                f.is_relative_to(dir)
+                for dir in dirs_to_keep
+            )
+            if not keep_file:
+                stale_artifacts.append(str(f))
+
+        self.logger.debug(f"Stale artifacts found: {stale_artifacts}")
+
+        return stale_artifacts
+
+    def __run(self) -> None:
+        """
+        Iterates over the list of stale build artifacts
+        and deletes them from the file system.
+        """
+        for path in self.__stale_artifacts_path_list():
+            self.logger.info(f"Removing stale artifacts at {path}")
+            shutil.rmtree(path=path)
+        return
+
+    @staticmethod
+    def get_singleton() -> "BuildArtifactsCleaner":
+        """
+        Returns the singleton instance of the BuildArtifactsCleaner class.
+
+        Returns:
+            BuildArtifactsCleaner: The singleton instance of the cleaner.
+        """
+        return BuildArtifactsCleaner.__singleton

--- a/build_manager/manager.py
+++ b/build_manager/manager.py
@@ -1,0 +1,445 @@
+import time
+import redis
+import dill
+from enum import Enum
+from utils import RateLimiter
+import logging
+import hashlib
+from metadata_manager import RemoteInfo
+import os
+
+
+class BuildState(Enum):
+    PENDING = 0
+    RUNNING = 1
+    SUCCESS = 2
+    FAILURE = 3
+    ERROR = 4
+
+
+class BuildProgress:
+    def __init__(
+        self,
+        state: BuildState,
+        percent: int
+    ) -> None:
+        """
+        Initialise the progress property for a build,
+        including its state and completion percentage.
+
+        Parameters:
+            state (BuildState): The current state of the build.
+            percent (int): The completion percentage of the build (0-100).
+        """
+        self.state = state
+        self.percent = percent
+
+
+class BuildInfo:
+    def __init__(self,
+                 vehicle: str,
+                 remote_info: RemoteInfo,
+                 git_hash: str,
+                 board: str,
+                 selected_features: set) -> None:
+        """
+        Initialize build information object including vehicle,
+        remote, git hash, selected features, and progress of the build.
+        The progress percentage is initially 0 and the state is PENDING.
+
+        Parameters:
+            vehicle (str): The vehicle name or type associated with the build.
+            remote_info (RemoteInfo): The remote repository containing the
+            source commit to build on.
+            git_hash (str): The git commit hash to build on.
+            board (str): Board to build for.
+            selected_features (set): Set of features selected for the build.
+        """
+        self.vehicle = vehicle
+        self.remote_info = remote_info
+        self.git_hash = git_hash
+        self.board = board
+        self.selected_features = selected_features
+        self.progress = BuildProgress(
+            state=BuildState.PENDING,
+            percent=0
+        )
+        self.time_created = time.time()
+
+
+class BuildManager:
+    """
+    Class to manage the build lifecycle, including build submission,
+    announcements, progress updates, and retrieval of build-related
+    information.
+    """
+
+    __singleton = None
+
+    def __init__(self,
+                 outdir: str,
+                 redis_host: str = 'localhost',
+                 redis_port: int = 6379,
+                 redis_task_queue_name: str = 'builds-queue') -> None:
+        """
+        Initialide the BuildManager instance. This class is responsible
+        for interacting with Redis to store build metadata and managing
+        build tasks.
+
+        Parameters:
+            outdir (str): Path to the directory for storing build artifacts.
+            redis_host (str): Hostname of the Redis instance for storing build
+            metadata.
+            redis_port (int): Port of the Redis instance for storing build
+            metadata.
+            redis_task_queue_name (str): Redis List name to be used as the
+            task queue.
+
+        Raises:
+            RuntimeError: If an instance of this class already exists,
+            enforcing a singleton pattern.
+        """
+        if BuildManager.__singleton:
+            raise RuntimeError("BuildManager must be a singleton")
+
+        # Initialide Redis client without decoding responses
+        # as we use dill for serialization.
+        self.__redis_client = redis.Redis(
+            host=redis_host,
+            port=redis_port,
+            decode_responses=False
+        )
+        self.__task_queue = redis_task_queue_name
+        self.__outdir = outdir
+
+        # Initialide an IP-based rate limiter.
+        # Allow 10 builds per hour per client
+        self.__ip_rate_limiter = RateLimiter(
+            redis_host=redis_host,
+            redis_port=redis_port,
+            time_window_sec=3600,
+            allowed_requests=10
+        )
+        self.__build_entry_prefix = "buildmeta-"
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(
+            "Build Manager initialised with configuration: "
+            f"Redis host: {redis_host}, "
+            f"Redis port: {redis_port}, "
+            f"Redis task queue: {self.__task_queue}, "
+            f"Build output directory: {self.__outdir}, "
+            f"Build entry prefix: {self.__build_entry_prefix}"
+        )
+        BuildManager.__singleton = self
+
+    def __del__(self) -> None:
+        """
+        Gracefully close the Redis connection when the BuildManager instance
+        is deleted.
+        """
+        if self.__redis_client:
+            self.logger.debug("Closing Redis connection")
+            self.__redis_client.close()
+
+    def __key_from_build_id(self, build_id: str) -> str:
+        """
+        Generate the Redis key that stores the build information for the given
+        build ID.
+
+        Parameters:
+            build_id (str): The unique ID for the build.
+
+        Returns:
+            str: The Redis key containing the build information.
+        """
+        return self.__build_entry_prefix + build_id
+
+    def __build_id_from_key(self, key: str) -> str:
+        """
+        Extract the build ID from the given Redis key.
+
+        Parameters:
+            key (str): The Redis key storing build information.
+
+        Returns:
+            str: The build ID corresponding to the given Redis key.
+        """
+        return key[len(self.__build_entry_prefix):]
+
+    def get_outdir(self) -> str:
+        """
+        Return the directory where build artifacts are stored.
+
+        Returns:
+            str: Path to the output directory containing build artifacts.
+        """
+        return self.__outdir
+
+    def __generate_build_id(self, build_info: BuildInfo) -> str:
+        """
+        Generate a unique build ID based on the build information and
+        current timestamp. The build information is hashed and combined
+        with the time to generate the ID.
+
+        Parameters:
+            build_info (BuildInfo): The build information object.
+
+        Returns:
+            str: The generated build ID (64 characters).
+        """
+        h = hashlib.md5(
+            f"{build_info}-{time.time_ns()}".encode()
+        ).hexdigest()
+        bid = f"{build_info.vehicle}-{build_info.board}-{h}"
+        return bid
+
+    def submit_build(self,
+                     build_info: BuildInfo,
+                     client_ip: str) -> str:
+        """
+        Submit a new build request, generate a build ID, and queue the
+        build for processing.
+
+        Parameters:
+            build_info (BuildInfo): The build information.
+            client_ip (str): The IP address of the client submitting the
+            build request.
+
+        Returns:
+            str: The generated build ID for the submitted build.
+        """
+        self.__ip_rate_limiter.count(client_ip)
+        build_id = self.__generate_build_id(build_info)
+        self.__insert_build_info(build_id=build_id, build_info=build_info)
+        self.__queue_build(build_id=build_id)
+        return build_id
+
+    def __queue_build(self,
+                      build_id: str) -> None:
+        """
+        Add the build ID to the Redis task queue for processing.
+
+        Parameters:
+            build_id (str): The ID of the build to be queued.
+        """
+        self.__redis_client.rpush(
+            self.__task_queue,
+            build_id.encode()
+        )
+
+    def get_next_build_id(self) -> str:
+        """
+        Block until the next build ID is available in the task queue,
+        then return it.
+
+        Returns:
+            str: The ID of the next build to be processed.
+        """
+        _, build_id_encoded = self.__redis_client.blpop(self.__task_queue)
+        build_id = build_id_encoded.decode()
+        self.logger.debug(f"Next build id: {build_id}")
+        return build_id
+
+    def build_exists(self,
+                     build_id: str) -> bool:
+        """
+        Check if a build with the given ID exists in the datastore.
+
+        Parameters:
+            build_id (str): The ID of the build to check.
+
+        Returns:
+            bool: True if the build exists, False otherwise.
+        """
+        return self.__redis_client.exists(
+            self.__key_from_build_id(build_id=build_id)
+        )
+
+    def __insert_build_info(self,
+                            build_id: str,
+                            build_info: BuildInfo,
+                            ttl_sec: int = 86400) -> None:
+        """
+        Insert the build information into the datastore.
+
+        Parameters:
+            build_id (str): The ID of the build.
+            build_info (BuildInfo): The build information to store.
+            ttl_sec (int): Time-to-live (TTL) in seconds after which the
+            build expires.
+        """
+        if self.build_exists(build_id=build_id):
+            raise ValueError(f"Build with id {build_id} already exists")
+
+        key = self.__key_from_build_id(build_id)
+        self.logger.debug(
+            "Adding build info, "
+            f"Redis key: {key}, "
+            f"Build Info: {build_info}, "
+            f"TTL: {ttl_sec} sec"
+        )
+        self.__redis_client.set(
+            name=key,
+            value=dill.dumps(build_info),
+            ex=ttl_sec
+        )
+
+    def get_build_info(self,
+                       build_id: str) -> BuildInfo:
+        """
+        Retrieve the build information for the given build ID.
+
+        Parameters:
+            build_id (str): The ID of the build to retrieve.
+
+        Returns:
+            BuildInfo: The build information for the given build ID.
+        """
+        key = self.__key_from_build_id(build_id=build_id)
+        self.logger.debug(
+            f"Getting build info for build id {build_id}, Redis Key: {key}"
+        )
+        value = self.__redis_client.get(key)
+        self.logger.debug(f"Got value {value} at key {key}")
+        return dill.loads(value) if value else None
+
+    def __update_build_info(self,
+                            build_id: str,
+                            build_info: BuildInfo) -> None:
+        """
+        Update the build information for an existing build in datastore.
+
+        Parameters:
+            build_id (str): The ID of the build to update.
+            build_info (BuildInfo): The new build information to replace
+            the existing one.
+        """
+        key = self.__key_from_build_id(build_id=build_id)
+        self.logger.debug(
+            "Updating build info, "
+            f"Redis key: {key}, "
+            f"Build Info: {build_info}, "
+            f"TTL: Keeping Same"
+        )
+        self.__redis_client.set(
+            name=key,
+            value=dill.dumps(build_info),
+            keepttl=True
+        )
+
+    def update_build_progress_percent(self,
+                                      build_id: str,
+                                      percent: int) -> None:
+        """
+        Update the build's completion percentage.
+
+        Parameters:
+            build_id (str): The ID of the build to update.
+            percent (int): The new completion percentage (0-100).
+        """
+        build_info = self.get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"Build with id {build_id} not found.")
+
+        build_info.progress.percent = percent
+        self.__update_build_info(
+            build_id=build_id,
+            build_info=build_info
+        )
+
+    def update_build_progress_state(self,
+                                    build_id: str,
+                                    new_state: BuildState) -> None:
+        """
+        Update the build's state (e.g., PENDING, RUNNING, SUCCESS, FAILURE).
+
+        Parameters:
+            build_id (str): The ID of the build to update.
+            new_state (BuildState): The new state to set for the build.
+        """
+        build_info = self.get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"Build with id {build_id} not found.")
+
+        build_info.progress.state = new_state
+        self.__update_build_info(
+            build_id=build_id,
+            build_info=build_info
+        )
+
+    def get_all_build_ids(self) -> list:
+        """
+        Retrieve the IDs of all builds currently stored in the datastore.
+
+        Returns:
+            list: A list of all build IDs.
+        """
+        keys_encoded = self.__redis_client.keys(
+            f"{self.__build_entry_prefix}*"
+        )
+        keys = [key.decode() for key in keys_encoded]
+        self.logger.debug(
+            f"Keys with prefix {self.__build_entry_prefix}"
+            f": {keys}"
+        )
+        return [
+            self.__build_id_from_key(key)
+            for key in keys
+        ]
+
+    def get_build_artifacts_dir_path(self, build_id: str) -> str:
+        """
+        Return the directory at which the build artifacts are stored.
+
+        Parameters:
+            build_id (str): The ID of the build.
+
+        Returns:
+            str: The build artifacts path.
+        """
+        return os.path.join(
+            self.get_outdir(),
+            build_id,
+        )
+
+    def get_build_log_path(self, build_id: str) -> str:
+        """
+        Return the path at which the log for a build is written.
+
+        Parameters:
+            build_id (str): The ID of the build.
+
+        Returns:
+            str: The path at which the build log is written.
+        """
+        return os.path.join(
+            self.get_build_artifacts_dir_path(build_id),
+            'build.log'
+        )
+
+    def get_build_archive_path(self, build_id: str) -> str:
+        """
+        Return the path to the build archive.
+
+        Parameters:
+            build_id (str): The ID of the build.
+
+        Returns:
+            str: The path to the build archive.
+        """
+        return os.path.join(
+            self.get_build_artifacts_dir_path(build_id),
+            f"{build_id}.tar.gz"
+        )
+
+    @staticmethod
+    def get_singleton() -> "BuildManager":
+        """
+        Return the singleton instance of the BuildManager class.
+
+        Returns:
+            BuildManager: The singleton instance of the BuildManager.
+        """
+        return BuildManager.__singleton

--- a/build_manager/progress_updater.py
+++ b/build_manager/progress_updater.py
@@ -1,0 +1,353 @@
+import re
+import os
+import logging
+from utils import TaskRunner
+from pathlib import Path
+from .manager import (
+    BuildManager as bm,
+    BuildState
+)
+import json
+import time
+
+
+class BuildProgressUpdater:
+    """
+    Class for updating the progress of all builds.
+
+    This class ensures that the progress of all  builds is
+    updated periodically. It operates in a singleton pattern
+    to ensure only one instance manages the updates.
+    """
+
+    __singleton = None
+
+    def __init__(self):
+        """
+        Initialises the BuildProgressUpdater instance.
+
+        This uses the BuildManager singleton, so ensure that BuildManager is
+        initialised before creating a BuildProgressUpdater instance.
+
+        Raises:
+            RuntimeError: If BuildManager is not initialized or
+            if another instance of BuildProgressUpdater has already
+            been initialised.
+        """
+        if not bm.get_singleton():
+            raise RuntimeError("BuildManager should be initialised first")
+
+        if BuildProgressUpdater.__singleton:
+            raise RuntimeError("BuildProgressUpdater must be a singleton.")
+
+        self.__ensure_status_json()
+        # Set up a periodic task to update build progress every 3 seconds
+        # TaskRunner will handle scheduling and running the task.
+        tasks = (
+            (self.__update_build_progress_all, 3),
+        )
+        self.__runner = TaskRunner(tasks=tasks)
+        self.logger = logging.getLogger(__name__)
+        BuildProgressUpdater.__singleton = self
+
+    def start(self) -> None:
+        """
+        Start BuildProgressUpdater.
+        """
+        self.logger.info("Starting BuildProgressUpdater.")
+        self.__runner.start()
+
+    def __calc_running_build_progress_percent(self, build_id: str) -> int:
+        """
+        Calculate the progress percentage of a running build.
+
+        This method analyses the build log to determine the current completion
+        percentage by parsing the build steps from the log file.
+
+        Parameters:
+            build_id (str): The unique ID of the build for which progress is
+            calculated.
+
+        Returns:
+            int: The calculated build progress percentage (0 to 100).
+
+        Raises:
+            ValueError: If no build information is found for the provided
+            build ID.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"No build found with ID {build_id}")
+
+        if build_info.progress.state != BuildState.RUNNING:
+            raise RuntimeError(
+                "This method should only be called for running builds."
+            )
+
+        # Construct path to the build's log file
+        log_file_path = bm.get_singleton().get_build_log_path(build_id)
+        self.logger.debug(f"Opening log file: {log_file_path}")
+
+        try:
+            # Read the log content
+            with open(log_file_path, encoding='utf-8') as f:
+                build_log = f.read()
+        except FileNotFoundError:
+            self.logger.error(
+                f"Log file not found for RUNNING build with ID: {build_id}"
+            )
+            return build_info.progress.percent
+
+        # Regular expression to extract the build progress steps
+        compiled_regex = re.compile(r'(\[\D*(\d+)\D*\/\D*(\d+)\D*\])')
+        self.logger.debug(f"Regex pattern: {compiled_regex}")
+        all_matches = compiled_regex.findall(build_log)
+        self.logger.debug(f"Log matches: {all_matches}")
+
+        # If no matches are found, return a default progress value of 0
+        if len(all_matches) < 1:
+            return 0
+
+        completed_steps, total_steps = all_matches[-1][1:]
+        self.logger.debug(
+            f"Completed steps: {completed_steps},"
+            f"Total steps: {total_steps}"
+        )
+
+        # Handle initial compilation/linking steps (minor weight)
+        if int(total_steps) < 20:
+            return 1
+
+        # Handle building the OS phase (4% weight)
+        if int(total_steps) < 200:
+            return (int(completed_steps) * 4 // int(total_steps)) + 1
+
+        # Major build phase (95% weight)
+        return (int(completed_steps) * 95 // int(total_steps)) + 5
+
+    def __refresh_running_build_state(self, build_id: str) -> BuildState:
+        """
+        Refresh the state of a running build.
+
+        This method analyses the build log to determine the build has
+        concluded. If yes, it detects the success of a build by finding
+        the success message in the log.
+
+        Parameters:
+            build_id (str): The unique ID of the build for which progress is
+            calculated.
+
+        Returns:
+            BuildSate: The current build state based on the log.
+
+        Raises:
+            ValueError: If no build information is found for the provided
+            build ID.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"No build found with ID {build_id}")
+
+        if build_info.progress.state != BuildState.RUNNING:
+            raise RuntimeError(
+                "This method should only be called for running builds."
+            )
+
+        # Builder ships the archive post completion
+        # This is irrespective of SUCCESS or FAILURE
+        if not os.path.exists(
+            bm.get_singleton().get_build_archive_path(build_id)
+        ):
+            return BuildState.RUNNING
+
+        log_file_path = bm.get_singleton().get_build_log_path(build_id)
+        try:
+            # Read the log content
+            with open(log_file_path, encoding='utf-8') as f:
+                build_log = f.read()
+        except FileNotFoundError:
+            self.logger.error(
+                f"Log file not found for RUNNING build with ID: {build_id}"
+            )
+            return BuildState.ERROR
+
+        # Build has finished, check if it succeeded or failed
+        success_message_pos = build_log.find(
+            f"'{build_info.vehicle.lower()}' finished successfully"
+        )
+        if success_message_pos == -1:
+            return BuildState.FAILURE
+        else:
+            return BuildState.SUCCESS
+
+    def __update_build_percent(self, build_id: str) -> None:
+        """
+        Update the progress percentage of a given build.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"No build found with ID {build_id}")
+
+        current_state = build_info.progress.state
+        current_percent = build_info.progress.percent
+        new_percent = current_percent
+        self.logger.debug(
+            f"Build id: {build_id}, "
+            f"Current state: {current_state}, "
+            f"Current percentage: {current_percent}, "
+        )
+        if current_state == BuildState.PENDING:
+            # Keep existing percentage
+            pass
+        elif current_state == BuildState.RUNNING:
+            new_percent = self.__calc_running_build_progress_percent(build_id)
+        elif current_state == BuildState.SUCCESS:
+            new_percent = 100
+        elif current_state == BuildState.FAILURE:
+            # Keep existing percentage
+            pass
+        elif current_state == BuildState.ERROR:
+            # Keep existing percentage
+            pass
+        else:
+            raise Exception("Unhandled BuildState.")
+
+        self.logger.debug(
+            f"Build id: {build_id}, "
+            f"New percentage: {new_percent}, "
+        )
+        if new_percent != current_percent:
+            bm.get_singleton().update_build_progress_percent(
+                build_id=build_id,
+                percent=new_percent
+            )
+
+    def __update_build_state(self, build_id: str) -> None:
+        """
+        Update the state of a given build.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id=build_id)
+
+        if build_info is None:
+            raise ValueError(f"No build found with ID {build_id}")
+
+        current_state = build_info.progress.state
+        new_state = current_state
+        self.logger.debug(
+            f"Build id: {build_id}, "
+            f"Current state: {current_state.name}, "
+        )
+
+        log_file_path = bm.get_singleton().get_build_log_path(build_id)
+        if current_state == BuildState.PENDING:
+            # Builder creates log file when it starts
+            # running a build
+            if os.path.exists(log_file_path):
+                new_state = BuildState.RUNNING
+        elif current_state == BuildState.RUNNING:
+            new_state = self.__refresh_running_build_state(build_id)
+        elif current_state == BuildState.SUCCESS:
+            # SUCCESS is a conclusive state
+            pass
+        elif current_state == BuildState.FAILURE:
+            # FAILURE is a conclusive state
+            pass
+        elif current_state == BuildState.ERROR:
+            # ERROR is a conclusive state
+            pass
+        else:
+            raise Exception("Unhandled BuildState.")
+
+        self.logger.debug(
+            f"Build id: {build_id}, "
+            f"New state: {new_state.name}, "
+        )
+        if current_state != new_state:
+            bm.get_singleton().update_build_progress_state(
+                build_id=build_id,
+                new_state=new_state,
+            )
+
+    def __update_build_progress_all(self) -> None:
+        """
+        Update progress for all builds.
+
+        This method will iterate through all  builds, calculate their
+        progress, and update the build manager with the latest progress state
+        and percentage.
+        """
+        for build_id in bm.get_singleton().get_all_build_ids():
+            self.__update_build_state(build_id)
+            self.__update_build_percent(build_id)
+
+        # Generate status.json after updating build progress.
+        self.__generate_status_json()
+
+    def get_status_json_path(self) -> str:
+        """
+        Path to status.json file.
+        """
+        return os.path.join(
+            bm.get_singleton().get_outdir(),
+            'status.json'
+        )
+
+    def __ensure_status_json(self) -> None:
+        """
+        Ensures status.json exists and is a valid JSON file.
+        """
+        p = Path(self.get_status_json_path())
+
+        if not p.exists():
+            # Ensure parent directory exists
+            Path.mkdir(p.parent, parents=True, exist_ok=True)
+
+            # write empty json dict
+            with open(p, 'w') as f:
+                f.write('{}')
+
+    def __generate_status_json(self) -> None:
+        """
+        Rewrite status.json file.
+        """
+        all_build_ids_sorted = sorted(
+            bm.get_singleton().get_all_build_ids(),
+            key=lambda x: bm.get_singleton().get_build_info(x).time_created,
+            reverse=True
+        )
+
+        self.logger.debug(f"All build ids sorted: {all_build_ids_sorted}")
+        # To-do: fix status.json structure,
+        # write a list instead of a dict to the file
+        builds_dict = {}
+        for build_id in all_build_ids_sorted:
+            build_info = bm.get_singleton().get_build_info(build_id)
+            build_age_min = int(time.time() - build_info.time_created) // 60
+            bi_json = {
+                'vehicle': build_info.vehicle.capitalize(),
+                'board': build_info.board,
+                'git_hash_short': build_info.git_hash[:8],
+                'features': ', '.join(build_info.selected_features),
+                'status': build_info.progress.state.name,
+                'progress': build_info.progress.percent,
+                'age': "%u:%02u" % ((build_age_min // 60), build_age_min % 60)
+            }
+            self.logger.debug(f"Build info json: {bi_json}")
+            builds_dict[build_id] = bi_json
+        self.logger.debug(f"Builds dict: {builds_dict}")
+
+        with open(self.get_status_json_path(), 'w') as f:
+            f.write(json.dumps(builds_dict))
+
+    @staticmethod
+    def get_singleton() -> "BuildProgressUpdater":
+        """
+        Get the singleton instance of BuildProgressUpdater.
+
+        Returns:
+            BuildProgressUpdater: The singleton instance of this class.
+        """
+        return BuildProgressUpdater.__singleton

--- a/builder/__init__.py
+++ b/builder/__init__.py
@@ -1,0 +1,5 @@
+from .builder import Builder
+
+__all__ = [
+    "Builder",
+]

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from ap_git import GitRepo
+from build_manager import BuildManager
+from builder import Builder
+from metadata_manager import (
+    APSourceMetadataFetcher,
+)
+from logging.config import dictConfig
+
+dictConfig({
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'stream': {
+            'class': 'logging.StreamHandler',
+            'level': 'INFO',
+            'formatter': 'default',
+            'stream': sys.stdout,
+        },
+    },
+    'loggers': {
+        'root': {
+            'level': 'INFO',
+            'handlers': ['stream'],
+        },
+    },
+})
+
+if __name__ == "__main__":
+    basedir = os.path.abspath(os.getenv("CBS_BASEDIR"))
+    workdir = os.path.abspath('/workdir')
+
+    repo = GitRepo.clone_if_needed(
+        source="https://github.com/ardupilot/ardupilot.git",
+        dest=os.path.join(workdir, 'ardupilot'),
+    )
+
+    ap_metafetch = APSourceMetadataFetcher(
+        ap_repo=repo
+    )
+
+    manager = BuildManager(
+        outdir=os.path.join(basedir, 'builds'),
+        redis_host=os.getenv('CBS_REDIS_HOST', default='localhost'),
+        redis_port=os.getenv('CBS_REDIS_PORT', default='6379')
+    )
+
+    builder = Builder(
+        workdir=workdir,
+        source_repo=repo,
+    )
+    builder.run()

--- a/builder/builder.py
+++ b/builder/builder.py
@@ -1,0 +1,417 @@
+import ap_git
+from build_manager import (
+    BuildManager as bm,
+)
+import subprocess
+import os
+import shutil
+import logging
+import tarfile
+from metadata_manager import (
+    APSourceMetadataFetcher as apfetch,
+    RemoteInfo,
+)
+from pathlib import Path
+
+
+class Builder:
+    """
+    Processes build requests, perform builds and ship build artifacts
+    to the destination directory shared by BuildManager.
+    """
+
+    def __init__(self, workdir: str, source_repo: ap_git.GitRepo) -> None:
+        """
+        Initialises the Builder class.
+
+        Parameters:
+            workdir (str): Workspace for the builder.
+            source_repo (ap_git.GitRepo): Ardupilot repository to be used for
+                                          retrieving source for doing builds.
+
+        Raises:
+            RuntimeError: If BuildManager or APSourceMetadataFetcher is not
+            initialised.
+        """
+        if bm.get_singleton() is None:
+            raise RuntimeError(
+                "BuildManager should be initialized first."
+            )
+        if apfetch.get_singleton() is None:
+            raise RuntimeError(
+                "APSourceMetadataFetcher should be initialised first."
+            )
+
+        self.__workdir_parent = workdir
+        self.__master_repo = source_repo
+        self.logger = logging.getLogger(__name__)
+
+    def __log_build_info(self, build_id: str) -> None:
+        """
+        Logs the build information to the build log.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id)
+        logpath = bm.get_singleton().get_build_log_path(build_id)
+        with open(logpath, "a") as build_log:
+            build_log.write(f"Vehicle: {build_info.vehicle}\n"
+                            f"Board: {build_info.board}\n"
+                            f"Remote URL: {build_info.remote_info.url}\n"
+                            f"git-sha: {build_info.git_hash}\n"
+                            "---\n"
+                            "Selected Features:\n")
+            for d in build_info.selected_features:
+                build_log.write(f"{d}\n")
+            build_log.write("---\n")
+
+    def __generate_extrahwdef(self, build_id: str) -> None:
+        """
+        Generates the extra hardware definition file (`extra_hwdef.dat`) for
+        the build.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+
+        Raises:
+            RuntimeError: If the parent directory for putting `extra_hwdef.dat`
+            does not exist.
+        """
+        # Log to build log
+        logpath = bm.get_singleton().get_build_log_path(build_id)
+        with open(logpath, "a") as build_log:
+            build_log.write("Generating extrahwdef file...\n")
+
+        path = self.__get_path_to_extra_hwdef(build_id)
+        self.logger.debug(
+            f"Path to extra_hwdef for build id {build_id}: {path}"
+        )
+        if not os.path.exists(os.path.dirname(path)):
+            raise RuntimeError(
+                f"Create parent directory '{os.path.dirname(path)}' "
+                "before writing extra_hwdef.dat"
+            )
+
+        build_info = bm.get_singleton().get_build_info(build_id)
+        selected_features = build_info.selected_features
+        self.logger.debug(
+            f"Selected features for {build_id}: {selected_features}"
+        )
+        all_features = apfetch.get_singleton().get_build_options_at_commit(
+            remote=build_info.remote_info.name,
+            commit_ref=build_info.git_hash,
+        )
+        all_defines = {
+            feature.define
+            for feature in all_features
+        }
+        enabled_defines = selected_features.intersection(all_defines)
+        disabled_defines = all_defines.difference(enabled_defines)
+        self.logger.info(f"Enabled defines for {build_id}: {enabled_defines}")
+        self.logger.info(f"Disabled defines for {build_id}: {enabled_defines}")
+
+        with open(self.__get_path_to_extra_hwdef(build_id), "w") as f:
+            # Undefine all defines at the beginning
+            for define in all_defines:
+                f.write(f"undef {define}\n")
+            # Enable selected defines
+            for define in enabled_defines:
+                f.write(f"define {define} 1\n")
+            # Disable the remaining defines
+            for define in disabled_defines:
+                f.write(f"define {define} 0\n")
+
+    def __ensure_remote_added(self, remote_info: RemoteInfo) -> None:
+        """
+        Ensures that the remote repository is correctly added to the
+        master repository.
+
+        Parameters:
+            remote_info (RemoteInfo): Information about the remote repository.
+        """
+        try:
+            self.__master_repo.remote_add(
+                remote=remote_info.name,
+                url=remote_info.url,
+            )
+            self.logger.info(
+                f"Added remote {remote_info.name} to master repo."
+            )
+        except ap_git.DuplicateRemoteError:
+            self.logger.debug(
+                f"Remote {remote_info.name} already exists."
+                f"Setting URL to {remote_info.url}."
+            )
+            # Update the URL if the remote already exists
+            self.__master_repo.remote_set_url(
+                remote=remote_info.name,
+                url=remote_info.url,
+            )
+            self.logger.info(
+                f"Updated remote url to {remote_info.url}"
+                f"for remote {remote_info.name}"
+            )
+
+    def __provision_build_source(self, build_id: str) -> None:
+        """
+        Provisions the source code for a specific build.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        # Log to build log
+        logpath = bm.get_singleton().get_build_log_path(build_id)
+        with open(logpath, "a") as build_log:
+            build_log.write("Cloning build source...\n")
+
+        build_info = bm.get_singleton().get_build_info(build_id)
+        logging.info(
+            f"Ensuring {build_info.remote_info.name} is added to master repo."
+        )
+        self.__ensure_remote_added(build_info.remote_info)
+
+        logging.info(f"Cloning build source for {build_id} from master repo.")
+
+        ap_git.GitRepo.shallow_clone_at_commit_from_local(
+            source=self.__master_repo.get_local_path(),
+            remote=build_info.remote_info.name,
+            commit_ref=build_info.git_hash,
+            dest=self.__get_path_to_build_src(build_id),
+        )
+
+    def __create_build_artifacts_dir(self, build_id: str) -> None:
+        """
+        Creates the output directory to store build artifacts.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        p = Path(bm.get_singleton().get_build_artifacts_dir_path(build_id))
+        self.logger.info(f"Creating directory at {p}.")
+        try:
+            Path.mkdir(p, parents=True)
+        except FileExistsError:
+            shutil.rmtree(p)
+            Path.mkdir(p)
+
+    def __create_build_workdir(self, build_id: str) -> None:
+        """
+        Creates the working directory for the build.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        p = Path(self.__get_path_to_build_dir(build_id))
+        self.logger.info(f"Creating directory at {p}.")
+        try:
+            Path.mkdir(p, parents=True)
+        except FileExistsError:
+            shutil.rmtree(p)
+            Path.mkdir(p)
+
+    def __generate_archive(self, build_id: str) -> None:
+        """
+        Placeholder for generating the zipped build artifact.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        build_info = bm.get_singleton().get_build_info(build_id)
+        archive_path = bm.get_singleton().get_build_archive_path(build_id)
+
+        files_to_include = []
+
+        # include binaries
+        bin_path = os.path.join(
+            self.__get_path_to_build_dir(build_id),
+            build_info.board,
+            "bin"
+        )
+        bin_list = os.listdir(bin_path)
+        self.logger.debug(f"bin_path: {bin_path}")
+        self.logger.debug(f"bin_list: {bin_list}")
+        for file in bin_list:
+            file_path_abs = os.path.abspath(
+                os.path.join(bin_path, file)
+            )
+            files_to_include.append(file_path_abs)
+
+        # include log
+        log_path_abs = os.path.abspath(
+            bm.get_singleton().get_build_log_path(build_id)
+        )
+        files_to_include.append(log_path_abs)
+
+        # include extra_hwdef.dat
+        extra_hwdef_path_abs = os.path.abspath(
+            self.__get_path_to_extra_hwdef(build_id)
+        )
+        files_to_include.append(extra_hwdef_path_abs)
+
+        # create archive
+        with tarfile.open(archive_path, "w:gz") as tar:
+            for file in files_to_include:
+                arcname = f"{build_id}/{os.path.basename(file)}"
+                self.logger.debug(f"Added {file} as {arcname}")
+                tar.add(file, arcname=arcname)
+        self.logger.info(f"Generated {archive_path}.")
+
+    def __clean_up_build_workdir(self, build_id: str) -> None:
+        shutil.rmtree(self.__get_path_to_build_dir(build_id))
+
+    def __process_build(self, build_id: str) -> None:
+        """
+        Processes a new build by preparing source code and extra_hwdef file
+        and running the build finally.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+        """
+        self.__create_build_workdir(build_id)
+        self.__create_build_artifacts_dir(build_id)
+        self.__log_build_info(build_id)
+        self.__provision_build_source(build_id)
+        self.__generate_extrahwdef(build_id)
+        self.__build(build_id)
+        self.__generate_archive(build_id)
+        self.__clean_up_build_workdir(build_id)
+
+    def __get_path_to_build_dir(self, build_id: str) -> str:
+        """
+        Returns the path to the temporary workspace for a build.
+        This directory contains the source code and extra_hwdef.dat file.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+
+        Returns:
+            str: Path to the build directory.
+        """
+        return os.path.join(self.__workdir_parent, build_id)
+
+    def __get_path_to_extra_hwdef(self, build_id: str) -> str:
+        """
+        Returns the path to the extra_hwdef definition file for a build.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+
+        Returns:
+            str: Path to the extra hardware definition file.
+        """
+        return os.path.join(
+            self.__get_path_to_build_dir(build_id),
+            "extra_hwdef.dat",
+        )
+
+    def __get_path_to_build_src(self, build_id: str) -> str:
+        """
+        Returns the path to the source code for a build.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+
+        Returns:
+            str: Path to the build source directory.
+        """
+        return os.path.join(
+            self.__get_path_to_build_dir(build_id),
+            "build_src"
+        )
+
+    def __build(self, build_id: str) -> None:
+        """
+        Executes the actual build process for a build.
+        This should be called after preparing build source code and
+        extra_hwdef file.
+
+        Parameters:
+            build_id (str): Unique identifier for the build.
+
+        Raises:
+            RuntimeError: If source directory or extra hardware definition
+            file does not exist.
+        """
+        if not os.path.exists(self.__get_path_to_build_dir(build_id)):
+            raise RuntimeError("Creating build before building.")
+        if not os.path.exists(self.__get_path_to_build_src(build_id)):
+            raise RuntimeError("Cannot build without source code.")
+        if not os.path.exists(self.__get_path_to_extra_hwdef(build_id)):
+            raise RuntimeError("Cannot build without extra_hwdef.dat file.")
+
+        build_info = bm.get_singleton().get_build_info(build_id)
+        source_repo = ap_git.GitRepo(self.__get_path_to_build_src(build_id))
+
+        # Checkout the specific commit and ensure submodules are updated
+        source_repo.checkout_remote_commit_ref(
+            remote=build_info.remote_info.name,
+            commit_ref=build_info.git_hash,
+            force=True,
+            hard_reset=True,
+            clean_working_tree=True,
+        )
+        source_repo.submodule_update(init=True, recursive=True, force=True)
+
+        logpath = bm.get_singleton().get_build_log_path(build_id)
+        with open(logpath, "a") as build_log:
+            # Log initial configuration
+            build_log.write(
+                "Setting vehicle to: "
+                f"{build_info.vehicle.capitalize()}\n"
+            )
+            build_log.flush()
+
+            # Run the build steps
+            self.logger.info("Running waf configure")
+            build_log.write("Running waf configure\n")
+            build_log.flush()
+            subprocess.run(
+                [
+                    "python3",
+                    "./waf",
+                    "configure",
+                    "--board",
+                    build_info.board,
+                    "--out",
+                    self.__get_path_to_build_dir(build_id),
+                    "--extra-hwdef",
+                    self.__get_path_to_extra_hwdef(build_id),
+                ],
+                cwd=self.__get_path_to_build_src(build_id),
+                stdout=build_log,
+                stderr=build_log,
+                shell=False,
+            )
+
+            self.logger.info("Running clean")
+            build_log.write("Running clean\n")
+            build_log.flush()
+            subprocess.run(
+                ["python3", "./waf", "clean"],
+                cwd=self.__get_path_to_build_src(build_id),
+                stdout=build_log,
+                stderr=build_log,
+                shell=False,
+            )
+
+            self.logger.info("Running build")
+            build_log.write("Running build\n")
+            build_log.flush()
+            subprocess.run(
+                ["python3", "./waf", build_info.vehicle.lower()],
+                cwd=self.__get_path_to_build_src(build_id),
+                stdout=build_log,
+                stderr=build_log,
+                shell=False,
+            )
+            build_log.write("done build\n")
+            build_log.flush()
+
+    def run(self) -> None:
+        """
+        Continuously processes builds in the queue until termination.
+        """
+        while True:
+            build_to_process = bm.get_singleton().get_next_build_id()
+            self.__process_build(build_id=build_to_process)

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,0 +1,3 @@
+jsonschema
+redis
+dill==0.3.9

--- a/metadata_manager/__init__.py
+++ b/metadata_manager/__init__.py
@@ -1,4 +1,8 @@
-from .core import APSourceMetadataFetcher, VersionsFetcher
+from .core import (
+    APSourceMetadataFetcher,
+    VersionsFetcher,
+    RemoteInfo,
+)
 from .exceptions import (
     MetadataManagerException,
     TooManyInstancesError
@@ -8,5 +12,6 @@ __all__ = [
     "APSourceMetadataFetcher",
     "VersionsFetcher",
     "MetadataManagerException",
-    "TooManyInstancesError"
+    "TooManyInstancesError",
+    "RemoteInfo",
 ]

--- a/metadata_manager/core.py
+++ b/metadata_manager/core.py
@@ -227,6 +227,21 @@ class VersionsFetcher:
             for remote in self.__get_versions_metadata()
         ]
 
+    def get_remote_info(self, remote_name: str) -> RemoteInfo:
+        """
+        Return the RemoteInfo for the given remote name, None otherwise.
+
+        Returns:
+            RemoteInfo: The remote information object.
+        """
+        return next(
+            (
+                remote for remote in self.get_all_remotes_info()
+                if remote.name == remote_name
+            ),
+            None
+        )
+
     def get_versions_for_vehicle(self, vehicle_name: str) -> list[VersionInfo]:
         """
         Return the list of dictionaries containing the info about the

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,8 @@
 from .taskrunner import TaskRunner
+from .ratelimiter import RateLimiter, RateLimitExceededException
 
 __all__ = [
     "TaskRunner",
+    "RateLimiter",
+    "RateLimitExceededException"
 ]

--- a/utils/ratelimiter.py
+++ b/utils/ratelimiter.py
@@ -1,0 +1,127 @@
+import redis
+import logging
+
+
+class RateLimiter:
+    """
+    A rate limiter that uses Redis as a backend to store request counts.
+
+    This class allows you to limit the number of requests made by a client
+    (identified by a key) within a specified time window.
+    """
+    def __init__(self, redis_host: str, redis_port: int,
+                 time_window_sec: int, allowed_requests: int) -> None:
+        """
+        Initialises the RateLimiter instance.
+
+        Parameters:
+            redis_host (str): The Redis server hostname.
+            redis_port (int): The Redis server port.
+            time_window_sec (int): The time window (in seconds) in which
+            requests are counted.
+            allowed_requests (int): The maximum number of requests allowed
+            in the time window.
+        """
+        self.__redis_client = redis.Redis(
+            host=redis_host,
+            port=redis_port,
+            decode_responses=True
+        )
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(
+            f"Redis connection established with {redis_host}:{redis_port}"
+        )
+
+        # Unique key prefix for this rate limiter instance
+        self.__key_prefix = f"rl-{id(self)}-"
+        self.__time_window_sec = time_window_sec
+        self.__allowed_requests = allowed_requests
+
+        self.logger.info(
+            "RateLimiter initialized with parameters: "
+            f"Key prefix: {self.__key_prefix}, "
+            f"Time window: {self.__time_window_sec}s, "
+            f"Allowed requests per window: {self.__allowed_requests}"
+        )
+
+    def __del__(self) -> None:
+        """
+        Clean up and close the Redis connection when the RateLimiter
+        is deleted.
+        """
+        if self.__redis_client:
+            self.__redis_client.close()
+            self.logger.debug(
+                f"Redis connection closed for RateLimiter with id {id(self)}"
+            )
+
+    def __get_prefixed_key(self, key: str) -> str:
+        """
+        Generates a unique key for Redis by adding a prefix.
+
+        This helps avoid key collision in Redis with other data stored there.
+
+        Parameters:
+            key (str): The key (e.g., client identifier) to be used for rate
+            limiting.
+
+        Returns:
+            str: The Redis key with the instance-specific prefix.
+        """
+        return self.__key_prefix + key
+
+    def count(self, key: str) -> None:
+        """
+        Increment the request count for a specific key (e.g., an IP address)
+        within the current time window.
+
+        Parameters:
+            key (str): The key for which the request count is being updated.
+                      For example, an IP address if rate limiting based on IPs.
+
+        Raises:
+            RateLimitExceededException: If the number of requests exceeds the
+            allowed limit for the current time window.
+        """
+        self.logger.debug(f"Counting a request for key: {key}")
+        pfx_key = self.__get_prefixed_key(key)
+
+        # Check if the key already exists in Redis
+        if self.__redis_client.exists(pfx_key):
+            current_count = int(self.__redis_client.get(pfx_key))
+            self.logger.debug(
+                f"Current request count for '{pfx_key}': {current_count}"
+            )
+
+            # If request count exceeds the allowed limit, raise exception
+            if current_count >= self.__allowed_requests:
+                self.logger.warning(f"Rate limit exceeded for key '{pfx_key}'")
+                raise RateLimitExceededException
+
+            # Increment request count and keep TTL (time-to-live) unchanged
+            self.__redis_client.set(
+                name=pfx_key,
+                value=(current_count + 1),
+                keepttl=True
+            )
+        else:
+            # Key doesn't exist yet, initialise count with TTL for time window
+            self.logger.debug(
+                f"No previous requests for key '{pfx_key}' in current window"
+                ", initialising count to 1"
+            )
+            self.__redis_client.set(
+                name=pfx_key,
+                value=1,
+                ex=self.__time_window_sec
+            )
+
+
+class RateLimiterException(Exception):
+    pass
+
+
+class RateLimitExceededException(RateLimiterException):
+    def __init__(self, *args):
+        message = "Too many requests. Try after some time."
+        super().__init__(message)

--- a/web/app.py
+++ b/web/app.py
@@ -1,20 +1,10 @@
 #!/usr/bin/env python3
 
 import os
-import subprocess
-import json
-import pathlib
-import shutil
-import glob
-import time
-import fcntl
 import base64
-import hashlib
-from distutils.dir_util import copy_tree
-from flask import Flask, render_template, request, send_from_directory, render_template_string, jsonify, redirect
-from threading import Thread, Lock
+from flask import Flask, render_template, request, send_from_directory, jsonify, redirect
+from threading import Thread
 import sys
-import re
 import requests
 
 from logging.config import dictConfig
@@ -39,6 +29,8 @@ dictConfig({
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import ap_git
 import metadata_manager
+import build_manager
+from builder import Builder
 
 # run at lower priority
 os.nice(20)
@@ -59,15 +51,12 @@ cmd_opts, cmd_args = parser.parse_args()
 basedir = os.path.abspath(cmd_opts.basedir)
 sourcedir = os.path.join(basedir, 'ardupilot')
 outdir_parent = os.path.join(basedir, 'builds')
-tmpdir_parent = os.path.join(basedir, 'tmp')
+workdir_parent = os.path.join(basedir, 'workdir')
 
 appdir = os.path.dirname(__file__)
 
 builds_dict = {}
 REMOTES = None
-
-# LOCKS
-queue_lock = Lock()
 
 repo = ap_git.GitRepo.clone_if_needed(
     source="https://github.com/ardupilot/ardupilot.git",
@@ -82,319 +71,33 @@ versions_fetcher = metadata_manager.VersionsFetcher(
     remotes_json_path=os.path.join(basedir, 'configs', 'remotes.json'),
     ap_repo=repo
 )
+
+manager = build_manager.BuildManager(
+    outdir=outdir_parent,
+    redis_host=os.getenv('CBS_REDIS_HOST', default='localhost'),
+    redis_port=os.getenv('CBS_REDIS_PORT', default='6379')
+)
+cleaner = build_manager.BuildArtifactsCleaner()
+progress_updater = build_manager.BuildProgressUpdater()
+
 versions_fetcher.start()
+cleaner.start()
+progress_updater.start()
 
-def remove_directory_recursive(dirname):
-    '''remove a directory recursively'''
-    app.logger.info('Removing directory ' + dirname)
-    if not os.path.exists(dirname):
-        return
-    f = pathlib.Path(dirname)
-    if f.is_file():
-        f.unlink()
-    else:
-        shutil.rmtree(f, True)
-
-
-def create_directory(dir_path):
-    '''create a directory, don't fail if it exists'''
-    app.logger.info('Creating ' + dir_path)
-    pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
-
-
-def run_build(task, tmpdir, outdir, logpath):
-    '''run a build with parameters from task'''
-    remove_directory_recursive(tmpdir_parent)
-    create_directory(tmpdir)
-    tmp_src_dir = os.path.join(tmpdir, 'build_src')
-    source_repo = ap_git.GitRepo.shallow_clone_at_commit_from_local(
-        source=sourcedir,
-        remote=task['remote'],
-        commit_ref=task['git_hash_short'],
-        dest=tmp_src_dir
+if os.getenv('CBS_ENABLE_INBUILT_BUILDER', default='1') == '1':
+    builder = Builder(
+        workdir=workdir_parent,
+        source_repo=repo
     )
-    # update submodules in temporary source directory
-    source_repo.submodule_update(init=True, recursive=True, force=True)
-    # checkout to the commit pointing to the requested commit
-    source_repo.checkout_remote_commit_ref(
-        remote=task['remote'],
-        commit_ref=task['git_hash_short'],
-        force=True,
-        hard_reset=True,
-        clean_working_tree=True
+    builder_thread = Thread(
+        target=builder.run,
+        daemon=True
     )
-    if not os.path.isfile(os.path.join(outdir, 'extra_hwdef.dat')):
-        app.logger.error('Build aborted, missing extra_hwdef.dat')
-    app.logger.info('Appending to build.log')
-    with open(logpath, 'a') as log:
-
-        log.write('Setting vehicle to: ' + task['vehicle'].capitalize() + '\n')
-        log.flush()
-        # setup PATH to point at our compiler
-        env = os.environ.copy()
-        bindir1 = os.path.abspath(os.path.join(appdir, "..", "..", "bin"))
-        bindir2 = os.path.abspath(os.path.join(appdir, "..", "..", "gcc", "bin"))
-        cachedir = os.path.abspath(os.path.join(appdir, "..", "..", "cache"))
-
-        env["PATH"] = bindir1 + ":" + bindir2 + ":" + env["PATH"]
-        env['CCACHE_DIR'] = cachedir
-
-        app.logger.info('Running waf configure')
-        log.write('Running waf configure\n')
-        log.flush()
-        subprocess.run(['python3', './waf', 'configure',
-                        '--board', task['board'], 
-                        '--out', tmpdir, 
-                        '--extra-hwdef', task['extra_hwdef']],
-                        cwd = tmp_src_dir,
-                        env=env,
-                        stdout=log, stderr=log, shell=False)
-        app.logger.info('Running clean')
-        log.write('Running clean\n')
-        log.flush()
-        subprocess.run(['python3', './waf', 'clean'],
-                        cwd = tmp_src_dir, 
-                        env=env,
-                        stdout=log, stderr=log, shell=False)
-        app.logger.info('Running build')
-        log.write('Running build\n')
-        log.flush()
-        subprocess.run(['python3', './waf', task['vehicle']],
-                        cwd = tmp_src_dir,
-                        env=env,
-                        stdout=log, stderr=log, shell=False)
-        log.write('done build\n')
-        log.flush()
-
-def sort_json_files(reverse=False):
-    json_files = list(filter(os.path.isfile,
-                             glob.glob(os.path.join(outdir_parent,
-                                                    '*', 'q.json'))))
-    json_files.sort(key=lambda x: os.path.getmtime(x), reverse=reverse)
-    return json_files
-
-def check_queue():
-    '''thread to continuously run queued builds'''
-    queue_lock.acquire()
-    json_files = sort_json_files()
-    queue_lock.release()
-    if len(json_files) == 0:
-        return
-    # remove multiple build requests from same ip address (keep newest)
-    queue_lock.acquire()
-    ip_list = []
-    for f in json_files:
-        file = json.loads(open(f).read())
-        ip_list.append(file['ip'])
-    seen = set()
-    ip_list.reverse()
-    for index, value in enumerate(ip_list):
-        if value in seen:
-            file = json.loads(open(json_files[-index-1]).read())
-            outdir_to_delete = os.path.join(outdir_parent, file['token'])
-            remove_directory_recursive(outdir_to_delete)
-        else:
-            seen.add(value)
-    queue_lock.release()
-    if len(json_files) == 0:
-        return
-    # open oldest q.json file
-    json_files = sort_json_files()
-    taskfile = json_files[0]
-    app.logger.info('Opening ' + taskfile)
-    task = json.loads(open(taskfile).read())
-    app.logger.info('Removing ' + taskfile)
-    os.remove(taskfile)
-    outdir = os.path.join(outdir_parent, task['token'])
-    tmpdir = os.path.join(tmpdir_parent, task['token'])
-    logpath = os.path.abspath(os.path.join(outdir, 'build.log'))
-    app.logger.info("LOGPATH: %s" % logpath)
-    try:
-        # run build and rename build directory
-        app.logger.info('MIR: Running build ' + str(task))
-        run_build(task, tmpdir, outdir, logpath)
-        app.logger.info('Copying build files from %s to %s',
-                        os.path.join(tmpdir, task['board']),
-                            outdir)
-        copy_tree(os.path.join(tmpdir, task['board'], 'bin'), outdir)
-        app.logger.info('Build successful!')
-        remove_directory_recursive(tmpdir)
-
-    except Exception as ex:
-        app.logger.info('Build failed: ', ex)
-        pass
-    open(logpath,'a').write("\nBUILD_FINISHED\n")
-
-def file_age(fname):
-    '''return file age in seconds'''
-    return time.time() - os.stat(fname).st_mtime
-
-def remove_old_builds():
-    '''as a cleanup, remove any builds older than 24H'''
-    for f in os.listdir(outdir_parent):
-        bdir = os.path.join(outdir_parent, f)
-        if os.path.isdir(bdir) and file_age(bdir) > 24 * 60 * 60:
-            remove_directory_recursive(bdir)
-    time.sleep(5)
-
-def queue_thread():
-    while True:
-        try:
-            check_queue()
-            remove_old_builds()
-        except Exception as ex:
-            app.logger.error('Failed queue: ', ex)
-            pass
-
-def get_build_progress(build_id, build_status):
-    '''return build progress on scale of 0 to 100'''
-    if build_status in ['Pending', 'Error']:
-        return 0
-    
-    if build_status == 'Finished':
-        return 100
-    
-    log_file_path = os.path.join(outdir_parent,build_id,'build.log')
-    app.logger.info('Opening ' + log_file_path)
-    build_log = open(log_file_path, encoding='utf-8').read()
-    compiled_regex = re.compile(r'(\[\D*(\d+)\D*\/\D*(\d+)\D*\])')
-    all_matches = compiled_regex.findall(build_log)
-
-    if (len(all_matches) < 1):
-        return 0
-
-    completed_steps, total_steps = all_matches[-1][1:]
-    if (int(total_steps) < 20):
-        # these steps are just little compilation and linking that happen at initialisation
-        # these do not contribute significant percentage to overall build progress
-        return 1
-    
-    if (int(total_steps) < 200):
-        # these steps are for building the OS
-        # we give this phase 4% weight in the whole build progress
-        return (int(completed_steps) * 4 // int(total_steps)) + 1
-    
-    # these steps are the major part of the build process
-    # we give 95% of weight to these
-    return (int(completed_steps) * 95 // int(total_steps)) + 5
-
-
-def get_build_status(build_id):
-    build_id_split = build_id.split(':')
-    if len(build_id_split) < 2:
-        raise Exception('Invalid build id')
-
-    if os.path.exists(os.path.join(outdir_parent,build_id,'q.json')):
-        status = "Pending"
-    elif not os.path.exists(os.path.join(outdir_parent,build_id,'build.log')):
-        status = "Error"
-    else:
-        log_file_path = os.path.join(outdir_parent,build_id,'build.log')
-        app.logger.info('Opening ' + log_file_path)
-        build_log = open(log_file_path, encoding='utf-8').read()
-        if build_log.find("'%s' finished successfully" % build_id_split[0].lower()) != -1:
-            status = "Finished"
-        elif build_log.find('The configuration failed') != -1 or build_log.find('Build failed') != -1 or build_log.find('compilation terminated') != -1:
-            status = "Failed"
-        elif build_log.find('BUILD_FINISHED') == -1:
-            status = "Running"
-        else:
-            status = "Failed"
-    return status
-
-def update_build_dict():
-    '''update the build_dict dictionary which keeps track of status of all builds'''
-    global builds_dict
-    # get list of directories
-    blist = []
-    for b in os.listdir(outdir_parent):
-        if os.path.isdir(os.path.join(outdir_parent,b)):
-            blist.append(b)
-
-    #remove deleted builds from build_dict
-    for build in builds_dict:
-        if build not in blist:
-            builds_dict.pop(build, None)
-
-    for b in blist:
-        build_id_split = b.split(':')
-        if len(build_id_split) < 2:
-            continue
-        build_info = builds_dict.get(b, None)
-        # add an entry for the build in build_dict if not exists
-        if (build_info is None):
-            build_info = {}
-            build_info['vehicle'] = build_id_split[0].capitalize()
-            build_info['board'] = build_id_split[1]
-            feature_file = os.path.join(outdir_parent, b, 'selected_features.json')
-            app.logger.info('Opening ' + feature_file)
-            selected_features_dict = json.loads(open(feature_file).read())
-            selected_features = selected_features_dict['selected_features']
-            build_info['git_hash_short'] = selected_features_dict['git_hash_short']
-            features = ''
-            for feature in selected_features:
-                if features == '':
-                    features = features + feature
-                else:
-                    features = features + ", " + feature
-            build_info['features'] = features
-
-        age_min = int(file_age(os.path.join(outdir_parent,b))/60.0)
-        build_info['age'] = "%u:%02u" % ((age_min // 60), age_min % 60)
-
-        # refresh build status only if it was pending, running or not initialised
-        if (build_info.get('status', None) in ['Pending', 'Running', None]):
-            build_info['status'] = get_build_status(b)
-            build_info['progress'] = get_build_progress(b, build_info['status'])
-
-        # update dictionary entry
-        builds_dict[b] = build_info
-
-    temp_list = sorted(list(builds_dict.items()), key=lambda x: os.path.getmtime(os.path.join(outdir_parent,x[0])), reverse=True)
-    builds_dict = {ele[0] : ele[1]  for ele in temp_list}
-
-def create_status():
-    '''create status.json'''
-    global builds_dict
-    update_build_dict()
-    tmpfile = os.path.join(outdir_parent, "status.tmp")
-    statusfile = os.path.join(outdir_parent, "status.json")
-    json_object = json.dumps(builds_dict)
-    with open(tmpfile, "w") as outfile:
-        outfile.write(json_object)
-    os.replace(tmpfile, statusfile)
-
-def status_thread():
-    while True:
-        try:
-            create_status()
-        except Exception as ex:
-            app.logger.info(ex)
-            pass
-        time.sleep(3)
+    builder_thread.start()
 
 app = Flask(__name__, template_folder='templates')
 
-if not os.path.isdir(outdir_parent):
-    create_directory(outdir_parent)
-
-try:
-    lock_file = open(os.path.join(basedir, "queue.lck"), "w")
-    fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    app.logger.info("Got queue lock")
-    # we only want one set of threads
-    thread = Thread(target=queue_thread, args=())
-    thread.daemon = True
-    thread.start()
-
-    status_thread = Thread(target=status_thread, args=())
-    status_thread.daemon = True
-    status_thread.start()
-except IOError:
-    app.logger.info("No queue lock")
-
 versions_fetcher.reload_remotes_json()
-
 app.logger.info('Python version is: %s' % sys.version)
 
 def get_auth_token():
@@ -426,136 +129,68 @@ def refresh_remotes():
 @app.route('/generate', methods=['GET', 'POST'])
 def generate():
     try:
-        chosen_version = request.form['version']
-        chosen_remote, chosen_commit_reference = chosen_version.split('/', 1)
-        chosen_vehicle = request.form['vehicle']
-        chosen_version_info = versions_fetcher.get_version_info(
-            vehicle=chosen_vehicle,
-            remote=chosen_remote,
-            commit_ref=chosen_commit_reference
+        version = request.form['version']
+        remote_name, commit_ref = version.split('/', 1)
+        remote_info = versions_fetcher.get_remote_info(remote_name)
+
+        if remote_info is None:
+            raise Exception(f"Remote {remote_name} is not whitelisted.")
+
+        vehicle = request.form['vehicle']
+        version_info = versions_fetcher.get_version_info(
+            vehicle=vehicle,
+            remote=remote_name,
+            commit_ref=commit_ref
         )
 
-        if chosen_version_info is None:
+        if version_info is None:
             raise Exception("Commit reference invalid or not listed to be built for given vehicle for remote")
 
-        chosen_board = request.form['board']
+        board = request.form['board']
         boards_at_commit = ap_src_metadata_fetcher.get_boards_at_commit(
-            remote=chosen_remote,
-            commit_ref=chosen_commit_reference
+            remote=remote_name,
+            commit_ref=commit_ref
         )
-        if chosen_board not in boards_at_commit:
+        if board not in boards_at_commit:
             raise Exception("bad board")
 
-        #ToDo - maybe have the if-statement to check if it's changed.
-        build_options = ap_src_metadata_fetcher.get_build_options_at_commit(
-            remote=chosen_remote,
-            commit_ref=chosen_commit_reference
+        all_features = ap_src_metadata_fetcher.get_build_options_at_commit(
+            remote=remote_name,
+            commit_ref=commit_ref
         )
 
-        # fetch features from user input
-        extra_hwdef = []
-        feature_list = []
-        selected_features = []
-        app.logger.info('Fetching features from user input')
+        chosen_defines = {
+            feature.define
+            for feature in all_features
+            if request.form.get(feature.label) == "1"
+        }
 
-        # add all undefs at the start
-        for f in build_options:
-            extra_hwdef.append('undef %s' % f.define)
-
-        for f in build_options:
-            if f.label not in request.form or request.form[f.label] != '1':
-                extra_hwdef.append('define %s 0' % f.define)
-            else:
-                extra_hwdef.append('define %s 1' % f.define)
-                feature_list.append(f.description)
-                selected_features.append(f.label)
-
-        extra_hwdef = '\n'.join(extra_hwdef)
-        spaces = '\n'
-        feature_list = spaces.join(feature_list)
-        selected_features_dict = {}
-        selected_features_dict['selected_features'] = selected_features
-
-        queue_lock.acquire()
-
-        # create extra_hwdef.dat file and obtain md5sum
-        app.logger.info('Creating ' + 
-                        os.path.join(outdir_parent, 'extra_hwdef.dat'))
-        file = open(os.path.join(outdir_parent, 'extra_hwdef.dat'), 'w')
-        app.logger.info('Writing\n' + extra_hwdef)
-        file.write(extra_hwdef)
-        file.close()
-
-        extra_hwdef_md5sum = hashlib.md5(extra_hwdef.encode('utf-8')).hexdigest()
-        app.logger.info('Removing ' +
-                        os.path.join(outdir_parent, 'extra_hwdef.dat'))
-        os.remove(os.path.join(outdir_parent, 'extra_hwdef.dat'))
-
-        new_git_hash = repo.commit_id_for_remote_ref(
-            remote=chosen_remote,
-            commit_ref=chosen_commit_reference
+        git_hash = repo.commit_id_for_remote_ref(
+            remote=remote_name,
+            commit_ref=commit_ref
         )
-        git_hash_short = new_git_hash[:10]
-        app.logger.info('Git hash = ' + new_git_hash)
-        selected_features_dict['git_hash_short'] = git_hash_short
 
-        # create directories using concatenated token 
-        # of vehicle, board, git-hash of source, and md5sum of hwdef
-        token = chosen_vehicle.lower() + ':' + chosen_board + ':' + new_git_hash + ':' + extra_hwdef_md5sum
-        app.logger.info('token = ' + token)
-        outdir = os.path.join(outdir_parent, token)
+        build_info = build_manager.BuildInfo(
+            vehicle=vehicle,
+            remote_info=remote_info,
+            git_hash=git_hash,
+            board=board,
+            selected_features=chosen_defines
+        )
 
-        if os.path.isdir(outdir):
-            app.logger.info('Build already exists')
+        forwarded_for = request.headers.get('X-Forwarded-For', None)
+        if forwarded_for:
+            client_ip = forwarded_for.split(',')[0].strip()
         else:
-            create_directory(outdir)
-            # create build.log
-            build_log_info = ('Vehicle: ' + chosen_vehicle +
-                '\nBoard: ' + chosen_board +
-                '\nRemote: ' + chosen_remote +
-                '\ngit-sha: ' + git_hash_short +
-                '\nVersion: ' + chosen_version_info.release_type + '-' + chosen_version_info.version_number +
-                '\nSelected Features:\n' + feature_list +
-                '\n\nWaiting for build to start...\n\n')
-            app.logger.info('Creating build.log')
-            build_log = open(os.path.join(outdir, 'build.log'), 'w')
-            build_log.write(build_log_info)
-            build_log.close()
-            # create hwdef.dat
-            app.logger.info('Opening ' + 
-                            os.path.join(outdir, 'extra_hwdef.dat'))
-            file = open(os.path.join(outdir, 'extra_hwdef.dat'),'w')
-            app.logger.info('Writing\n' + extra_hwdef)
-            file.write(extra_hwdef)
-            file.close()
-            # fill dictionary of variables and create json file
-            task = {}
-            task['token'] = token
-            task['remote'] = chosen_remote
-            task['git_hash_short'] = git_hash_short
-            task['version'] = chosen_version_info.release_type + '-' + chosen_version_info.version_number
-            task['extra_hwdef'] = os.path.join(outdir, 'extra_hwdef.dat')
-            task['vehicle'] = chosen_vehicle.lower()
-            task['board'] = chosen_board
-            task['ip'] = request.remote_addr
-            app.logger.info('Opening ' + os.path.join(outdir, 'q.json'))
-            jfile = open(os.path.join(outdir, 'q.json'), 'w')
-            app.logger.info('Writing task file to ' + 
-                            os.path.join(outdir, 'q.json'))
-            jfile.write(json.dumps(task, separators=(',\n', ': ')))
-            jfile.close()
-            # create selected_features.dat for status table
-            feature_file = open(os.path.join(outdir, 'selected_features.json'), 'w')
-            app.logger.info('Writing\n' + os.path.join(outdir, 'selected_features.json'))
-            feature_file.write(json.dumps(selected_features_dict))
-            feature_file.close()
+            client_ip = request.remote_addr
 
-        queue_lock.release()
+        build_id = manager.submit_build(
+            build_info=build_info,
+            client_ip=client_ip,
+        )
 
-        base_url = request.url_root
-        app.logger.info(base_url)
         app.logger.info('Redirecting to /viewlog')
-        return redirect('/viewlog/'+token)
+        return redirect('/viewlog/'+build_id)
 
     except Exception as ex:
         app.logger.error(ex)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,3 +1,5 @@
 flask
 requests
 jsonschema
+dill==0.3.8
+redis==5.2.1

--- a/web/static/js/index.js
+++ b/web/static/js/index.js
@@ -51,11 +51,11 @@ function updateBuildsTable(status_json) {
     Object.keys(status_json).forEach((build_id) => {
         let build_info = status_json[build_id];
         let status_color = 'primary';
-        if (build_info['status'] == 'Finished') {
+        if (build_info['status'] == 'SUCCESS') {
             status_color = 'success';
-        } else if (build_info['status'] == 'Pending') {
+        } else if (build_info['status'] == 'PENDING') {
             status_color = 'warning';
-        } else if (build_info['status'] == 'Failed' || build_info['status'] == 'Error') {
+        } else if (build_info['status'] == 'FAILURE' || build_info['status'] == 'ERROR') {
             status_color = 'danger';
         }
 


### PR DESCRIPTION
This PR introduces the build_manager and builder modules to the application, improving the build process by dedicating specific tasks to each and also clean up the app.py file.

- `build_manager` handles accepting build requests, queuing them, storing build metadata, and managing related tasks.
- `builder` is responsible for executing the actual builds.

To efficiently handle queuing, I've integrated Redis, a fast in-memory datastore. Since build metadata is frequently accessed, storing it in memory enhances performance. Additionally, Redis will also be used for caching the board and build options list (an upcoming PR will address this).

These modules contain sub-modules such as:
- `cleaner` – for cleaning up build artifacts.
- `progress_updater` – for tracking and updating build progress.

We also introduce dependencies like the RateLimiter module, which helps build_manager rate-limit requests based on IP.