### PR TITLE
Fix path for setup and requirement.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The default directory structure is as follows:
 ### Install Dependencies
 
 ```bash
-cd ~/CustomBuild
+cd ~/CustomBuild/web
 python3 -m pip install --user --upgrade --requirement requirements.txt
 ```
 
@@ -63,7 +63,7 @@ python3 -m pip install --user --upgrade --requirement requirements.txt
 To run, in the CustomBuild directory execute the following command:
 
 ```bash
-cd ~/CustomBuild
+cd ~/CustomBuild/web
 ./app.py
 ```
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 jsonschema
+setuptools


### PR DESCRIPTION
I have follow the README to run the server and I have found 2 issues :
- requirement.txt and app.py is in the directory custombuild/web and not custombuild/
- Since python 3.10, setuptools is needed in requirement.txt