### PR TITLE
utils: wrap target method call in TaskRunner inside try-except

### DIFF
--- a/utils/taskrunner.py
+++ b/utils/taskrunner.py
@@ -46,7 +46,13 @@ class TaskRunner:
                         f"Now: {now}, Calling: {str(to_call)}, "
                         f"Runner id: {id(self)}"
                     )
-                    to_call()  # Call the method
+                    # Keep the thread alive even if an exception occurs
+                    # so that other tasks can keep running
+                    try:
+                        to_call()  # Call the method
+                    except Exception as e:
+                        logger.exception(e)
+
                     next_call_times[i] = now + period
 
             # Wait for the next call or stop event


### PR DESCRIPTION
TaskRunner accepts a list of tasks which it executes at a given interval. Each TaskRunner object spawns a separate thread to execute the assigned list of tasks. With current design, if an exception occurs while executing any of the tasks, the thread dies and the other tasks would not execute due to that.
This change wraps those method calls inside a try-except block and just prints the exception when it occurs and keeps executing the tasks as expected. 