### PR TITLE
Fix CMD in web/Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     build:
       context: .
       dockerfile: ./web/Dockerfile
-    command: gunicorn wsgi:application
     environment:
       CBS_REDIS_HOST: redis
       CBS_REDIS_PORT: 6379

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /app/web
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
-CMD ["/bin/sh", "./start.sh"]
+CMD ["gunicorn", "wsgi:application"]


### PR DESCRIPTION
Let us not override command in docker-compose and use the same in dockerfile itself.