### PR TITLE
Use Github Access token for fetching tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       CBS_BASEDIR: /base
       CBS_LOG_LEVEL: ${CBS_LOG_LEVEL:-INFO}
       CBS_ENABLE_INBUILT_BUILDER: 0
+      CBS_GITHUB_ACCESS_TOKEN: ${CBS_GITHUB_ACCESS_TOKEN}
       PYTHONPATH: /app
       GUNICORN_CMD_ARGS: --bind=0.0.0.0:80 --timeout=300
     volumes:

--- a/scripts/fetch_releases.py
+++ b/scripts/fetch_releases.py
@@ -41,6 +41,11 @@ def fetch_tags_from_github():
         'X-GitHub-Api-Version': '2022-11-28',
         'Accept': 'application/vnd.github+json'
     }
+
+    token = os.getenv("CBS_GITHUB_ACCESS_TOKEN")
+    if token:
+        headers['Authorization'] = f"Bearer {token}"
+
     response = requests.get(url=url, headers=headers)
     if response.status_code != 200:
         print(response.text)

--- a/scripts/fetch_whitelisted_tags.py
+++ b/scripts/fetch_whitelisted_tags.py
@@ -63,6 +63,11 @@ def fetch_tags_from_github(remote):
         'X-GitHub-Api-Version': '2022-11-28',
         'Accept': 'application/vnd.github+json'
     }
+
+    token = os.getenv("CBS_GITHUB_ACCESS_TOKEN")
+    if token:
+        headers['Authorization'] = f"Bearer {token}"
+
     response = requests.get(url=url, headers=headers)
     if response.status_code != 200:
         print(response.text)


### PR DESCRIPTION
We seem to be getting rate limited by github api sometimes due to a very low rate limit of 50 requests per hour for unauthenticated requests. With token, we get 5000 requests per hour. 