### PR TITLE
web: enable download only when build is success

### DIFF
--- a/web/static/js/index.js
+++ b/web/static/js/index.js
@@ -74,6 +74,10 @@ function updateBuildsTable(builds) {
         const features_string = build_info['selected_features'].join(', ')
         const build_age = timeAgo(build_info['time_created'])
 
+        const isSuccess = build_info['progress']['state'] === 'SUCCESS';
+        const downloadDisabled = !isSuccess ? 'disabled' : '';
+        const download_button_color = isSuccess ? 'primary' : 'secondary';
+
         table_body_html +=  `<tr>
                                 <td class="align-middle"><span class="badge text-bg-${status_color}">${build_info['progress']['state']}</span></td>
                                 <td class="align-middle">${build_age}</td>
@@ -94,7 +98,7 @@ function updateBuildsTable(builds) {
                                     <button class="btn btn-md btn-outline-primary m-1 tooltip-button" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-title="View log" onclick="launchLogModal('${build_info['build_id']}');">
                                         <i class="bi bi-file-text"></i>
                                     </button>
-                                    <button class="btn btn-md btn-outline-primary m-1 tooltip-button" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-title="Download build artifacts" id="${build_info['build_id']}-download-btn" onclick="window.location.href='/builds/${build_info['build_id']}/artifacts/${build_info['build_id']}.tar.gz';">
+                                    <button class="btn btn-md btn-outline-${download_button_color} m-1 tooltip-button" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-title="Download build artifacts" id="${build_info['build_id']}-download-btn" onclick="window.location.href='/builds/${build_info['build_id']}/artifacts/${build_info['build_id']}.tar.gz';" ${downloadDisabled}>
                                         <i class="bi bi-download"></i>
                                     </button>
                                 </td>


### PR DESCRIPTION
Currently user is able to download the firmware in any state [ running, failed, error ]
After this change download button can be clickable only when the build is completed with success

Fixes #177 

before: 
<img width="1920" height="1080" alt="custom_builder_setup" src="https://github.com/user-attachments/assets/98a59db0-bec4-4397-a817-e9d9bd69bc5f" />
 
 after:
<img width="1920" height="1080" alt="build_server_after_change" src="https://github.com/user-attachments/assets/b8d920f6-f06d-41a6-a453-0243f4504620" />

Followup :
The ardupilot wiki for build server have an incorrect step , should i update that and raise a pr to ardupilot_wiki ?
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0ba0b075-ec3d-43f8-ab91-ffdcfbd949b2" />

