### PR TITLE
Fix: Handle rate limit exceptions with proper HTTP 429 response

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -31,6 +31,7 @@ import ap_git
 import metadata_manager
 import build_manager
 from builder import Builder
+from utils.ratelimiter import RateLimitExceededException
 
 # run at lower priority
 os.nice(20)
@@ -220,6 +221,9 @@ def generate():
         app.logger.info('Redirecting to /viewlog')
         return redirect('/viewlog/'+build_id)
 
+    except RateLimitExceededException as ex:
+        app.logger.warning(f"Rate limit exceeded for client: {request.remote_addr}")
+        return render_template('error.html', ex=ex), 429
     except Exception as ex:
         app.logger.error(ex)
         return render_template('error.html', ex=ex)


### PR DESCRIPTION
Fixes #207 

The "/generate" endpoint now properly catches "RateLimitExceededException" and returns HTTP 429 with a clear error message instead of a generic 500 error when users exceed the build limit (10 builds/hour).

Changes:

Import "RateLimitExceededException"
Add exception handler before generic catch-all
Return HTTP 429 status with user-friendly message
Log rate limit violations for monitoring