### PR TITLE
Fix Windows compatibility: handle os.nice() AttributeError

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -33,8 +33,12 @@ import build_manager
 from builder import Builder
 from utils.ratelimiter import RateLimitExceededException
 
-# run at lower priority
-os.nice(20)
+# run at lower priority (Unix only)
+try:
+    os.nice(20)
+except AttributeError:
+    # Windows doesn't support os.nice()
+    pass
 
 import optparse
 parser = optparse.OptionParser("app.py")


### PR DESCRIPTION
Fixes #213

Application crashes on Windows with `AttributeError: module 'os' has no attribute 'nice'`.

Solution
Wrapped `os.nice(20)` in try-catch block to handle Windows compatibility.

Changes
- Added try-catch around `os.nice(20)` in `web/app.py`
- Windows: Gracefully skips the call
- Unix/Linux: Works as before

Result
- Application now starts successfully on Windows
