### PR TITLE
web: use absolute import paths for modules

### DIFF
--- a/web/api/v1/__init__.py
+++ b/web/api/v1/__init__.py
@@ -1,4 +1,4 @@
 """API v1 module."""
-from .router import router
+from web.api.v1.router import router
 
 __all__ = ["router"]

--- a/web/api/v1/admin.py
+++ b/web/api/v1/admin.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, HTTPException, Depends, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from schemas import RefreshRemotesResponse
-from services.admin import get_admin_service, AdminService
+from web.schemas import RefreshRemotesResponse
+from web.services.admin import get_admin_service, AdminService
 
 
 router = APIRouter(prefix="/admin", tags=["admin"])

--- a/web/api/v1/builds.py
+++ b/web/api/v1/builds.py
@@ -10,13 +10,13 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, PlainTextResponse
 
-from schemas import (
+from web.schemas import (
     BuildRequest,
     BuildSubmitResponse,
     BuildOut,
 )
-from services.builds import get_builds_service, BuildsService
-from core.limiter import limiter
+from web.services.builds import get_builds_service, BuildsService
+from web.core.limiter import limiter
 
 router = APIRouter(prefix="/builds", tags=["builds"])
 

--- a/web/api/v1/router.py
+++ b/web/api/v1/router.py
@@ -6,7 +6,7 @@ to be included in the main FastAPI application.
 """
 from fastapi import APIRouter
 
-from . import vehicles, builds, admin
+from web.api.v1 import vehicles, builds, admin
 
 # Create the main v1 router
 router = APIRouter(prefix="/v1")

--- a/web/api/v1/vehicles.py
+++ b/web/api/v1/vehicles.py
@@ -1,13 +1,13 @@
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Path
 
-from schemas import (
+from web.schemas import (
     VehicleBase,
     VersionOut,
     BoardOut,
     FeatureOut,
 )
-from services.vehicles import get_vehicles_service, VehiclesService
+from web.services.vehicles import get_vehicles_service, VehiclesService
 
 router = APIRouter(prefix="/vehicles", tags=["vehicles"])
 

--- a/web/core/__init__.py
+++ b/web/core/__init__.py
@@ -1,8 +1,8 @@
 """
 Core application components.
 """
-from .config import get_settings
-from .startup import initialize_application
+from web.core.config import get_settings
+from web.core.startup import initialize_application
 
 __all__ = [
     "get_settings",

--- a/web/core/limiter.py
+++ b/web/core/limiter.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from core.config import get_settings
+from web.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 

--- a/web/main.py
+++ b/web/main.py
@@ -14,13 +14,13 @@ from fastapi.staticfiles import StaticFiles
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
-from api.v1 import router as v1_router
-from ui import router as ui_router
+from web.api.v1 import router as v1_router
+from web.ui import router as ui_router
 
-from core.config import get_settings
-from core.startup import initialize_application
-from core.logging_config import setup_logging
-from core.limiter import limiter, rate_limit_exceeded_handler
+from web.core.config import get_settings
+from web.core.startup import initialize_application
+from web.core.logging_config import setup_logging
+from web.core.limiter import limiter, rate_limit_exceeded_handler
 
 import ap_git
 import metadata_manager

--- a/web/schemas/__init__.py
+++ b/web/schemas/__init__.py
@@ -6,12 +6,12 @@ across the API endpoints.
 """
 
 # Admin schemas
-from .admin import (
+from web.schemas.admin import (
     RefreshRemotesResponse,
 )
 
 # Build schemas
-from .builds import (
+from web.schemas.builds import (
     BuildVersionInfo,
     RemoteInfo,
     BuildProgress,
@@ -21,7 +21,7 @@ from .builds import (
 )
 
 # Vehicle schemas
-from .vehicles import (
+from web.schemas.vehicles import (
     VehicleBase,
     VersionBase,
     VersionOut,

--- a/web/schemas/builds.py
+++ b/web/schemas/builds.py
@@ -1,7 +1,7 @@
 from typing import List, Literal
 
 from pydantic import BaseModel, Field
-from schemas.vehicles import VehicleBase, BoardBase, RemoteInfo
+from web.schemas.vehicles import VehicleBase, BoardBase, RemoteInfo
 
 
 # --- Build Progress ---

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -1,9 +1,9 @@
 """
 Business logic services for the application.
 """
-from .vehicles import get_vehicles_service, VehiclesService
-from .builds import get_builds_service, BuildsService
-from .admin import get_admin_service, AdminService
+from web.services.vehicles import get_vehicles_service, VehiclesService
+from web.services.builds import get_builds_service, BuildsService
+from web.services.admin import get_admin_service, AdminService
 
 __all__ = [
     "get_vehicles_service",

--- a/web/services/builds.py
+++ b/web/services/builds.py
@@ -6,7 +6,7 @@ import os
 from fastapi import Request
 from typing import List, Optional
 
-from schemas import (
+from web.schemas import (
     BuildRequest,
     BuildSubmitResponse,
     BuildOut,
@@ -14,7 +14,7 @@ from schemas import (
     RemoteInfo,
     BuildVersionInfo,
 )
-from schemas.vehicles import VehicleBase, BoardBase
+from web.schemas.vehicles import VehicleBase, BoardBase
 
 # Import external modules
 # pylint: disable=wrong-import-position

--- a/web/services/vehicles.py
+++ b/web/services/vehicles.py
@@ -5,7 +5,7 @@ import logging
 from typing import List, Optional
 from fastapi import Request
 
-from schemas import (
+from web.schemas import (
     VehicleBase,
     RemoteInfo,
     VersionOut,

--- a/web/ui/__init__.py
+++ b/web/ui/__init__.py
@@ -1,6 +1,6 @@
 """
 UI module for web interface routes.
 """
-from .router import router
+from web.ui.router import router
 
 __all__ = ["router"]


### PR DESCRIPTION
This PR updates import statements throughout the `web` directory to use absolute imports with full module paths instead of relative imports. The relative imports were causing problems when I was writing tests. This change also improves code clarity, maintainability, and reduces potential import errors.
