### PR TITLE
web: make rate limiter storage uri configurable

### DIFF
--- a/web/core/config.py
+++ b/web/core/config.py
@@ -68,6 +68,21 @@ class Settings:
         return os.path.join(self.base_dir, 'configs', 'remotes.json')
 
     @property
+    def rate_limiter_storage_uri(self) -> str:
+        """
+        Storage URI for the rate limiter.
+
+        Uses CBS_RATE_LIMITER_STORAGE_URI env var if set and non-empty,
+        otherwise falls back to redis backend. When using the redis backend,
+        db index 1 is used to avoid conflicts with any other components that
+        use db index 0.
+        """
+        uri = os.getenv('CBS_RATE_LIMITER_STORAGE_URI', '').strip()
+        if uri:
+            return uri
+        return f"redis://{self.redis_host}:{self.redis_port}/1"
+
+    @property
     def enable_inbuilt_builder(self) -> bool:
         """Whether to enable the inbuilt builder."""
         return os.getenv('CBS_ENABLE_INBUILT_BUILDER', '1') == '1'

--- a/web/core/limiter.py
+++ b/web/core/limiter.py
@@ -10,13 +10,9 @@ logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
-# We use the same redis instance which is used to store build metadata
-# and other cached data. To keep that data separate, we use db-1 of the
-# redis instance instead of the default db-0.
-REDIS_DB_NUMBER = 1
 limiter = Limiter(
     key_func=get_remote_address,
-    storage_uri=f"redis://{settings.redis_host}:{settings.redis_port}/{REDIS_DB_NUMBER}",
+    storage_uri=settings.rate_limiter_storage_uri,
     strategy="fixed-window",
 )
 


### PR DESCRIPTION
This eliminates the need to necessarily use redis as the storage backend for rate limiter. That would help in overriding the storage uri in the tests (for build api) to use in memory storage instead of redis.

The PR to add the builds api tests will follow this. 