### PR TITLE
ap_git: force-create temp branch while shallow cloning from local repo

### DIFF
--- a/ap_git/core.py
+++ b/ap_git/core.py
@@ -276,18 +276,24 @@ class GitRepo:
         subprocess.run(cmd, cwd=self.__local_path, shell=False)
 
     def __branch_create(self, branch_name: str,
-                        start_point: str = None) -> None:
+                        start_point: str = None,
+                        force: bool = False) -> None:
         """
         Create a new branch starting from a given commit.
 
         Parameters:
             branch_name (str): Name of the branch to create
             start_point (str): Starting commit or branch (optional)
+            force (bool): Force creation, resetting the branch tip if it
+                          already exists (default is False)
         """
         if branch_name is None:
             raise ValueError("branch_name is required, cannot be None.")
 
         cmd = ['git', 'branch', branch_name]
+
+        if force:
+            cmd.append('-f')
 
         if start_point:
             if not self.__is_commit_present_locally(commit_ref=start_point):
@@ -626,7 +632,7 @@ class GitRepo:
         # as shallow clone needs a branch
         temp_branch_name = "temp-b-" + commit_id
         source_repo.__branch_create(
-            branch_name=temp_branch_name, start_point=commit_id
+            branch_name=temp_branch_name, start_point=commit_id, force=True
         )
 
         # perform the clone from the source repository


### PR DESCRIPTION
Any failure between `__branch_create` and `__branch_delete` can leave behind a stale temp branch, which can cause failures when we try to create a branch with the same name in subsequent builds.

Since `shallow_clone_at_commit_from_local` is the only function that creates these temp branches and expects the temp branch to always track the required commit, we can force-create it to handle cases where a stale branch is left behind from a previous failure.