### PR TITLE
docker-compose.yaml: add restart-always to app service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: .
       dockerfile: ./web/Dockerfile
+    restart: always
     environment:
       CBS_REDIS_HOST: redis
       CBS_REDIS_PORT: 6379


### PR DESCRIPTION
To ensure that the web app comes back on server reboots.