### PR TITLE
Shorten build ids and name archives `<vehicle>-<board-id>.tar.gz`

### DIFF
--- a/build_manager/manager.py
+++ b/build_manager/manager.py
@@ -200,13 +200,12 @@ class BuildManager:
             build_info (BuildInfo): The build information object.
 
         Returns:
-            str: The generated build ID (64 characters).
+            str: The generated build ID (8 characters).
         """
         h = hashlib.md5(
             f"{build_info}-{time.time_ns()}".encode()
-        ).hexdigest()
-        bid = f"{build_info.vehicle_id}-{build_info.board}-{h}"
-        return bid
+        ).hexdigest()[:8]
+        return h
 
     def submit_build(self,
                      build_info: BuildInfo) -> str:
@@ -460,19 +459,23 @@ class BuildManager:
             'build.log'
         )
 
-    def get_build_archive_path(self, build_id: str) -> str:
+    def get_build_archive_path(
+        self, build_id: str, vehicle_id: str, board: str
+    ) -> str:
         """
         Return the path to the build archive.
 
         Parameters:
             build_id (str): The ID of the build.
+            vehicle_id (str): The vehicle identifier.
+            board (str): The board identifier.
 
         Returns:
             str: The path to the build archive.
         """
         return os.path.join(
             self.get_build_artifacts_dir_path(build_id),
-            f"{build_id}.tar.gz"
+            f"{vehicle_id}-{board}-{build_id}.tar.gz"
         )
 
     @staticmethod

--- a/build_manager/progress_updater.py
+++ b/build_manager/progress_updater.py
@@ -186,7 +186,9 @@ class BuildProgressUpdater:
         # Builder ships the archive post completion
         # This is irrespective of SUCCESS or FAILURE
         if not os.path.exists(
-            bm.get_singleton().get_build_archive_path(build_id)
+            bm.get_singleton().get_build_archive_path(
+                build_id, build_info.vehicle_id, build_info.board
+            )
         ):
             return BuildState.RUNNING
 

--- a/builder/builder.py
+++ b/builder/builder.py
@@ -226,7 +226,9 @@ class Builder:
             build_id (str): Unique identifier for the build.
         """
         build_info = bm.get_singleton().get_build_info(build_id)
-        archive_path = bm.get_singleton().get_build_archive_path(build_id)
+        archive_path = bm.get_singleton().get_build_archive_path(
+            build_id, build_info.vehicle_id, build_info.board
+        )
 
         files_to_include = []
 
@@ -261,10 +263,11 @@ class Builder:
         )
         files_to_include.append(extra_hwdef_path_abs)
 
-        # create archive
+        # create archive (inner folder matches download basename)
+        folder_name = Path(archive_path).name.removesuffix(".tar.gz")
         with tarfile.open(archive_path, "w:gz") as tar:
             for file in files_to_include:
-                arcname = f"{build_id}/{os.path.basename(file)}"
+                arcname = f"{folder_name}/{os.path.basename(file)}"
                 self.logger.debug(f"Added {file} as {arcname}")
                 tar.add(file, arcname=arcname)
         self.logger.info(f"Generated {archive_path}.")

--- a/web/api/v1/builds.py
+++ b/web/api/v1/builds.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional
 from fastapi import (
     APIRouter,
@@ -219,5 +220,5 @@ async def download_artifact(
     return FileResponse(
         path=artifact_path,
         media_type='application/gzip',
-        filename=f"{build_id}.tar.gz"
+        filename=os.path.basename(artifact_path)
     )

--- a/web/services/builds.py
+++ b/web/services/builds.py
@@ -282,7 +282,9 @@ class BuildsService:
         ]:
             return None
 
-        artifact_path = self.manager.get_build_archive_path(build_id)
+        artifact_path = self.manager.get_build_archive_path(
+            build_id, build_info.vehicle_id, build_info.board
+        )
         if os.path.exists(artifact_path):
             return artifact_path
 


### PR DESCRIPTION
Build ids are now an 8 character hex hash instead of the long vehicle-board-hash string. Archives are named `{vehicle}-{board}-{id}.tar.gz`, and the folder inside the tarball matches that basename so downloads unpack cleanly.

We do not do huge builds daily. A very large build id leads to very long file names for no reason and is also difficult to render on frontend.

Made with [Cursor](https://cursor.com)