### PR TITLE
web: show unknown release types as "custom"

### DIFF
--- a/web/schemas/vehicles.py
+++ b/web/schemas/vehicles.py
@@ -21,7 +21,7 @@ class RemoteInfo(BaseModel):
 class VersionBase(BaseModel):
     id: str = Field(..., description="Unique version identifier")
     name: str = Field(..., description="Version display name")
-    type: Literal["beta", "stable", "latest", "tag"] = Field(
+    type: Literal["beta", "stable", "latest", "tag", "custom"] = Field(
         ..., description="Version type classification"
     )
     remote: RemoteInfo = Field(

--- a/web/services/vehicles.py
+++ b/web/services/vehicles.py
@@ -80,10 +80,16 @@ class VehiclesService:
                 remote = version_info.remote_info.name
                 title = f"{rel_type} {ver_num} ({remote})"
 
+            _KNOWN_TYPES = {"beta", "stable", "latest", "tag"}
+            release_type = (
+                version_info.release_type
+                if version_info.release_type in _KNOWN_TYPES
+                else "custom"
+            )
             versions.append(VersionOut(
                 id=version_info.version_id,
                 name=title,
-                type=version_info.release_type,
+                type=release_type,
                 remote=RemoteInfo(
                     name=version_info.remote_info.name,
                     url=version_info.remote_info.url,


### PR DESCRIPTION
...to support listing _custom_ versions in remotes.json